### PR TITLE
fix: Add missing edges

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -275,6 +275,22 @@ mod tests {
     use std::fs;
 
     #[test]
+    fn test_nodes_in_between() {
+        let mut graph = Graph::<u32, Edge, Directed>::new();
+        let weight = 1;
+        let node0 = graph.add_node(weight.clone());
+        let node1 = graph.add_node(weight.clone());
+        let _node2 = graph.add_node(weight.clone());
+        let node3 = graph.add_node(weight.clone());
+        let node4 = graph.add_node(weight.clone());
+        let node5 = graph.add_node(weight.clone());
+
+        let nodes = vec![node0, node1, node3, node4, node5];
+        let nodes_in_between = nodes_in_between(&node0.index(), &node5.index(), &nodes);
+        assert_eq!(nodes_in_between, 1);
+    }
+
+    #[test]
     fn test_node_distance() {
         let mut graph = Graph::<u32, Edge, Directed>::new();
         let weight = 1;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -156,7 +156,7 @@ impl VariantGraph {
         for ((sample, _), nodes) in supporting_reads {
             for node_tuple in nodes.iter().sorted().dedup().combinations(2).filter(|v| {
                 node_distance(&v[0].index(), &v[1].index()) <= 1
-                    || nodes_in_between(&v[0].index(), &v[1].index(), &nodes) == 0
+                    || nodes_in_between(&v[0].index(), &v[1].index(), nodes) == 0
             }) {
                 let edge = self.0.find_edge(*node_tuple[0], *node_tuple[1]);
                 if let Some(edge) = edge {
@@ -257,8 +257,13 @@ pub(crate) fn node_distance(node1: &usize, node2: &usize) -> usize {
     }
 }
 
-pub(crate) fn nodes_in_between(node1: &usize, node2: &usize, nodes: &Vec<NodeIndex>) -> usize {
-    unimplemented!()
+pub(crate) fn nodes_in_between(node1: &usize, node2: &usize, nodes: &[NodeIndex]) -> usize {
+    nodes
+        .iter()
+        .filter(|n| n.index() < *node2 && *node1 < n.index())
+        .filter(|n| node_distance(node1, &n.index()) != 0)
+        .filter(|n| node_distance(&n.index(), node2) != 0)
+        .count()
 }
 
 // test node distance

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -154,13 +154,10 @@ impl VariantGraph {
         supporting_reads: &HashMap<(String, Option<u64>), Vec<NodeIndex>>,
     ) -> Result<()> {
         for ((sample, _), nodes) in supporting_reads {
-            for node_tuple in nodes
-                .iter()
-                .sorted()
-                .dedup()
-                .combinations(2)
-                .filter(|v| node_distance(&v[0].index(), &v[1].index()) <= 1)
-            {
+            for node_tuple in nodes.iter().sorted().dedup().combinations(2).filter(|v| {
+                node_distance(&v[0].index(), &v[1].index()) <= 1
+                    || nodes_in_between(&v[0].index(), &v[1].index(), &nodes) == 0
+            }) {
                 let edge = self.0.find_edge(*node_tuple[0], *node_tuple[1]);
                 if let Some(edge) = edge {
                     let edge = self.0.edge_weight_mut(edge).unwrap();
@@ -258,6 +255,10 @@ pub(crate) fn node_distance(node1: &usize, node2: &usize) -> usize {
     } else {
         (distance + 1) / 2
     }
+}
+
+pub(crate) fn nodes_in_between(node1: &usize, node2: &usize, nodes: &Vec<NodeIndex>) -> usize {
+    unimplemented!()
 }
 
 // test node distance


### PR DESCRIPTION
This PR adds missing edges connecting subgraphs that were filtered out before but need to be included. This is caused by paired reads mainly.