### PR TITLE
fix: Consider splicing for each transcript by joining paths for CDSs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,8 @@ impl Command {
                 let reference_genome = utils::fasta::read_reference(reference);
                 for transcript in transcripts(features)? {
                     info!("Processing transcript {}", transcript.name());
+                    let weights = transcript.weights(graph, &reference_genome)?;
+                    // -------- old ----------
                     if let Ok(graph) = feature_graph(
                         graph.to_owned(),
                         transcript.target.to_string(),
@@ -116,11 +118,16 @@ impl Command {
                             )),
                         };
                         let weights = weights?;
-                        info!("Writing {} paths for CDS {}", weights.len(), cds.name());
-                        write_paths(output, weights, cds)?;
+                        // ------------ old ------------
                     } else {
-                        anyhow::bail!("No variant graph found for target {}", cds.target);
+                        anyhow::bail!("No variant graph found for target {}", transcript.target);
                     }
+                    info!(
+                        "Writing {} paths for Transcript {}",
+                        weights.len(),
+                        transcript.name()
+                    );
+                    write_paths(output, weights, transcript)?;
                 }
             }
             Command::Plot {

--- a/src/show/mod.rs
+++ b/src/show/mod.rs
@@ -13,12 +13,16 @@ use tera::Tera;
 /// * `output_path` - A reference to a `PathBuf` that holds the path of the directory where the rendered JSON file will be saved.
 /// * `paths` - A slice of `Weight` structs that will be serialized and passed to the template.
 /// * `feature` - A string that represents the feature name, which will be used as the filename.
-pub(crate) fn render_vl_paths(output_path: &PathBuf, paths: &[Weight], cds: Cds) -> Result<()> {
+pub(crate) fn render_vl_paths(
+    output_path: &PathBuf,
+    paths: &[Weight],
+    transcript: String,
+) -> Result<()> {
     let template = include_str!("../../resources/templates/paths.vl.json.tera");
     let mut context = tera::Context::new();
     context.insert("paths", paths);
     std::fs::write(
-        Path::new(output_path).join(format!("{}.json", cds.name())),
+        Path::new(output_path).join(format!("{}.json", transcript)),
         Tera::one_off(template, &context, false)?,
     )?;
     Ok(())
@@ -31,8 +35,12 @@ pub(crate) fn render_vl_paths(output_path: &PathBuf, paths: &[Weight], cds: Cds)
 /// * `output_path` - A reference to a `PathBuf` that holds the path of the directory where the rendered TSV file will be saved.
 /// * `paths` - A slice of `Weight` structs that will be serialized and written to the TSV file.
 /// * `feature` - A string that represents the feature name, which will be used as the filename.
-pub(crate) fn render_tsv_paths(output_path: &PathBuf, paths: &[Weight], cds: Cds) -> Result<()> {
-    let mut wtr = Writer::from_path(Path::new(output_path).join(format!("{}.tsv", cds.name())))?;
+pub(crate) fn render_tsv_paths(
+    output_path: &PathBuf,
+    paths: &[Weight],
+    transcript: String,
+) -> Result<()> {
+    let mut wtr = Writer::from_path(Path::new(output_path).join(format!("{}.tsv", transcript)))?;
     for path in paths {
         wtr.serialize(path)?;
     }
@@ -47,12 +55,16 @@ pub(crate) fn render_tsv_paths(output_path: &PathBuf, paths: &[Weight], cds: Cds
 /// * `output_path` - A reference to a `PathBuf` that holds the path of the directory where the rendered HTML file will be saved.
 /// * `paths` - A slice of `Weight` structs that will be serialized and passed to the template.
 /// * `feature` - A string that represents the feature name, which will be used as the filename.
-pub(crate) fn render_html_paths(output_path: &PathBuf, paths: &[Weight], cds: Cds) -> Result<()> {
+pub(crate) fn render_html_paths(
+    output_path: &PathBuf,
+    paths: &[Weight],
+    transcript: String,
+) -> Result<()> {
     let template = include_str!("../../resources/templates/paths.html.tera");
     let mut context = tera::Context::new();
     context.insert("paths", paths);
     std::fs::write(
-        Path::new(output_path).join(format!("{}.html", cds.name())),
+        Path::new(output_path).join(format!("{}.html", transcript)),
         Tera::one_off(template, &context, false)?,
     )?;
     Ok(())
@@ -77,9 +89,9 @@ mod tests {
             consequence: Some("loss".to_string()),
             sample: "sample1".to_string(),
         }];
-        let cds = Cds::new("1".to_string(), "some feature".to_string(), 1, 100);
-        render_vl_paths(&output_path, &paths, cds.clone()).unwrap();
-        let file_path = Path::new(&output_path).join(format!("{}.json", cds.name()));
+        let transcript = "some feature".to_string();
+        render_vl_paths(&output_path, &paths, transcript.clone()).unwrap();
+        let file_path = Path::new(&output_path).join(format!("{}.json", transcript));
         assert!(file_path.exists());
         let file_content = std::fs::read_to_string(file_path).unwrap();
         assert!(serde_json::from_str::<Value>(&file_content).is_ok());
@@ -98,9 +110,9 @@ mod tests {
             consequence: Some("loss".to_string()),
             sample: "sample1".to_string(),
         }];
-        let cds = Cds::new("1".to_string(), "some feature".to_string(), 1, 100);
-        render_tsv_paths(&output_path, &paths, cds.clone()).unwrap();
-        let file_path = Path::new(&output_path).join(format!("{}.tsv", cds.name()));
+        let transcript = "some feature".to_string();
+        render_tsv_paths(&output_path, &paths, transcript.clone()).unwrap();
+        let file_path = Path::new(&output_path).join(format!("{}.tsv", transcript));
         assert!(file_path.exists());
         let mut rdr = csv::Reader::from_path(file_path).unwrap();
         let result: Vec<Weight> = rdr.deserialize().map(|r| r.unwrap()).collect();
@@ -120,9 +132,9 @@ mod tests {
             consequence: Some("loss".to_string()),
             sample: "sample1".to_string(),
         }];
-        let cds = Cds::new("1".to_string(), "some feature".to_string(), 1, 100);
-        render_html_paths(&output_path, &paths, cds.clone()).unwrap();
-        let file_path = Path::new(&output_path).join(format!("{}.html", cds.name()));
+        let transcript = "some feature".to_string();
+        render_html_paths(&output_path, &paths, transcript.clone()).unwrap();
+        let file_path = Path::new(&output_path).join(format!("{}.html", transcript));
         assert!(file_path.exists());
     }
 }

--- a/tests/resources/Homo_sapiens.GRCh38.112.chromosome.6.gff3
+++ b/tests/resources/Homo_sapiens.GRCh38.112.chromosome.6.gff3
@@ -16,4 +16,5 @@
 6	havana	five_prime_UTR	29942404	29942553	.	+	.	Parent=transcript:ENST00000396634
 6	havana	exon	29942404	29942626	.	+	.	Parent=transcript:ENST00000396634;Name=ENSE00001633002;constitutive=0;ensembl_end_phase=1;ensembl_phase=-1;exon_id=ENSE00001633002;rank=3;version=1
 6	havana	CDS	29942554	29942626	.	+	0	ID=CDS:ENSP00000379873;Parent=transcript:ENST00000396634;protein_id=ENSP00000379873
+6	havana	CDS	29942726	29942926	.	+	0	ID=CDS:ENSP00000379873;Parent=transcript:ENST00000396634;protein_id=ENSP00000379873
 ###


### PR DESCRIPTION
This pull request includes significant changes to the `src/graph` and `src/main.rs` files, primarily focusing on replacing the `Cds` struct with a new `Transcript` struct, updating related functions, and modifying the database schema. The most important changes are summarized below:

### Structural Changes:
* [`src/graph/paths.rs`](diffhunk://#diff-f830d3b5556f7095af5617d054cebd450544c4eee4630f701b3fd7f679139aeeR1-R17): Replaced the `Cds` struct with a new `Transcript` struct, which includes multiple `Cds` instances and additional attributes like `strand` and methods for handling coding sequences and weights. [[1]](diffhunk://#diff-f830d3b5556f7095af5617d054cebd450544c4eee4630f701b3fd7f679139aeeR1-R17) [[2]](diffhunk://#diff-f830d3b5556f7095af5617d054cebd450544c4eee4630f701b3fd7f679139aeeL28-R226)
* [`src/graph/duck.rs`](diffhunk://#diff-9b9d93358f18dfc5ede9bd0b2d9d029a7381f54b7e47dcad35205c3b55c6b39bL151-R169): Updated functions to use `Transcript` instead of `Cds`, including changes to the database schema and SQL queries. [[1]](diffhunk://#diff-9b9d93358f18dfc5ede9bd0b2d9d029a7381f54b7e47dcad35205c3b55c6b39bL151-R169) [[2]](diffhunk://#diff-9b9d93358f18dfc5ede9bd0b2d9d029a7381f54b7e47dcad35205c3b55c6b39bL192-R203) [[3]](diffhunk://#diff-9b9d93358f18dfc5ede9bd0b2d9d029a7381f54b7e47dcad35205c3b55c6b39bL211-R213)

### Function Updates:
* [`src/graph/duck.rs`](diffhunk://#diff-9b9d93358f18dfc5ede9bd0b2d9d029a7381f54b7e47dcad35205c3b55c6b39bL151-R169): Modified `write_paths` and `read_paths` functions to handle `Transcript` instead of `Cds`. [[1]](diffhunk://#diff-9b9d93358f18dfc5ede9bd0b2d9d029a7381f54b7e47dcad35205c3b55c6b39bL151-R169) [[2]](diffhunk://#diff-9b9d93358f18dfc5ede9bd0b2d9d029a7381f54b7e47dcad35205c3b55c6b39bL192-R203)
* [`src/graph/paths.rs`](diffhunk://#diff-f830d3b5556f7095af5617d054cebd450544c4eee4630f701b3fd7f679139aeeL28-R226): Added new methods in `Transcript` for handling coding sequences, calculating start and end positions, and generating weights. [[1]](diffhunk://#diff-f830d3b5556f7095af5617d054cebd450544c4eee4630f701b3fd7f679139aeeL28-R226) [[2]](diffhunk://#diff-f830d3b5556f7095af5617d054cebd450544c4eee4630f701b3fd7f679139aeeR276-R283)

### Test Updates:
* `src/graph/duck.rs` and `src/graph/paths.rs`: Updated tests to reflect the changes from `Cds` to `Transcript`, ensuring compatibility with the new structure. [[1]](diffhunk://#diff-9b9d93358f18dfc5ede9bd0b2d9d029a7381f54b7e47dcad35205c3b55c6b39bL401-R410) [[2]](diffhunk://#diff-9b9d93358f18dfc5ede9bd0b2d9d029a7381f54b7e47dcad35205c3b55c6b39bL461-R479) [[3]](diffhunk://#diff-f830d3b5556f7095af5617d054cebd450544c4eee4630f701b3fd7f679139aeeL321-R488)

### Main File Updates:
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL3-R3): Refactored command implementations to use the new `transcripts` function and handle `Transcript` objects, including changes to path writing and rendering functions. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL3-R3) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL67-R77) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL142-R96)

These changes collectively enhance the flexibility and functionality of the codebase by introducing a more comprehensive `Transcript` structure and updating related functions and tests accordingly.