### PR TITLE
perf: Add threads option and parallelize build and process command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Use `predictosaurus --help` to view general help information, or `predictosaurus
 
 ## Commands
 
+All commands provide a verbose output with logging information via the `--verbose`/`-v` flag. Additionally the `--threads`/`-t` flag allows for multi-threaded execution. If not specified or `0`, the number of threads is set to the number of available logical cores.
+
 ### Build
 
 Builds a full variant graph from VCF files and stores it.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,10 @@ pub(crate) struct Predictosaurus {
 
     #[clap(short, long, global = true)]
     pub(crate) verbose: bool,
+
+    /// Number of threads to use (default: all available cores)
+    #[arg(short, long)]
+    pub(crate) threads: Option<usize>,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/graph/duck.rs
+++ b/src/graph/duck.rs
@@ -181,7 +181,7 @@ pub(crate) fn write_scores(
     let mut stmt = transaction.prepare("INSERT INTO scores VALUES (?, ?)")?;
     let transcript_name = transcript.name();
     for score in scores {
-        stmt.execute([transcript_name.to_string(), score.normalized().to_string()])?;
+        stmt.execute(params![transcript_name.as_str(), score.normalized()])?;
     }
     transaction.commit()?;
     db.close().unwrap();

--- a/src/graph/duck.rs
+++ b/src/graph/duck.rs
@@ -173,16 +173,17 @@ pub(crate) fn create_scores(output_path: &Path) -> Result<()> {
 
 pub(crate) fn write_scores(
     path: &Path,
-    scores: Vec<EffectScore>,
+    scores: &[EffectScore],
     transcript: Transcript,
 ) -> Result<()> {
-    let db = Connection::open(path)?;
+    let mut db = Connection::open(path)?;
+    let transaction = db.transaction()?;
+    let mut stmt = transaction.prepare("INSERT INTO scores VALUES (?, ?)")?;
+    let transcript_name = transcript.name();
     for score in scores {
-        db.execute(
-            "INSERT INTO scores VALUES (?, ?)",
-            [transcript.name(), score.normalized().to_string()],
-        )?;
+        stmt.execute([transcript_name.to_string(), score.normalized().to_string()])?;
     }
+    transaction.commit()?;
     db.close().unwrap();
     Ok(())
 }
@@ -567,7 +568,7 @@ mod tests {
             distance_metric: DistanceMetric::default(),
         };
         let scores = vec![effect_score];
-        write_scores(output_path.as_path(), scores, transcript).unwrap();
+        write_scores(output_path.as_path(), &scores, transcript).unwrap();
         let scores = read_scores(output_path.as_path()).unwrap();
         assert_eq!(scores.len(), 1);
         assert!((scores.get("chr1:some feature").unwrap()[0] - 0.3333333).abs() < 1e-6);

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ impl Command {
                         scores.len(),
                         transcript.name()
                     );
-                    write_scores(output, scores, transcript)?;
+                    write_scores(output, &scores, transcript)?;
                 }
             }
             Command::Peptides {


### PR DESCRIPTION
This pull request introduces multi-threading support to predictosaurus, allowing users to specify the number of threads for parallel processing. It also refactors several functions to leverage parallelism for improved performance and updates database operations for efficiency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added -t/--threads option to control number of threads (defaults to all available cores).
* **Performance**
  * Graph builds run in parallel across targets for faster execution.
  * Transcript processing is parallelized to reduce total runtime on multi-core systems.
* **Reliability**
  * Results are written transactionally to prevent partial writes and improve consistency.
* **Documentation**
  * README updated to document verbose output and thread option behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->