### PR TITLE
fix: Fix contains_variant to take target string argument

### DIFF
--- a/src/graph/paths.rs
+++ b/src/graph/paths.rs
@@ -43,17 +43,19 @@ impl Cds {
     }
 
     /// Returns true if the CDS contains the variant
-    pub(crate) fn contains_variant(&self, variants: &HashMap<String, BTreeSet<i64>>) -> bool {
-        for variant in variants.values() {
-            if variant
+    pub(crate) fn contains_variant(
+        &self,
+        target: &str,
+        variants: &HashMap<String, BTreeSet<i64>>,
+    ) -> bool {
+        if let Some(variant_positions) = variants.get(target) {
+            variant_positions
                 .range(self.start as i64..=self.end as i64)
                 .next()
                 .is_some()
-            {
-                return true;
-            }
+        } else {
+            false
         }
-        false
     }
 
     /// Length of CDS segment
@@ -320,39 +322,44 @@ mod tests {
     #[test]
     fn contains_variant_returns_true_when_variant_in_range() {
         let cds = Cds::new(10, 20, 0);
+        let target = "chr1";
         let mut variants = HashMap::new();
-        variants.insert("variant1".to_string(), BTreeSet::from([15]));
-        assert!(cds.contains_variant(&variants));
+        variants.insert(target.to_string(), BTreeSet::from([15]));
+        assert!(cds.contains_variant(target, &variants));
     }
 
     #[test]
     fn contains_variant_returns_false_when_variant_out_of_range() {
         let cds = Cds::new(10, 20, 0);
+        let target = "chr1";
         let mut variants = HashMap::new();
-        variants.insert("variant1".to_string(), BTreeSet::from([25]));
-        assert!(!cds.contains_variant(&variants));
+        variants.insert(target.to_string(), BTreeSet::from([25]));
+        assert!(!cds.contains_variant(target, &variants));
     }
 
     #[test]
     fn contains_variant_returns_false_when_no_variants() {
         let cds = Cds::new(10, 20, 0);
+        let target = "chr1";
         let variants: HashMap<String, BTreeSet<i64>> = HashMap::new();
-        assert!(!cds.contains_variant(&variants));
+        assert!(!cds.contains_variant(target, &variants));
     }
 
     #[test]
     fn contains_variant_returns_true_when_multiple_variants_in_range() {
         let cds = Cds::new(10, 20, 0);
+        let target = "chr1";
         let mut variants = HashMap::new();
-        variants.insert("variant1".to_string(), BTreeSet::from([12, 18]));
-        assert!(cds.contains_variant(&variants));
+        variants.insert(target.to_string(), BTreeSet::from([12, 18]));
+        assert!(cds.contains_variant(target, &variants));
     }
 
     #[test]
     fn contains_variant_returns_true_when_variants_on_boundary() {
         let cds = Cds::new(10, 20, 0);
+        let target = "chr1";
         let mut variants = HashMap::new();
-        variants.insert("variant1".to_string(), BTreeSet::from([10, 20]));
-        assert!(cds.contains_variant(&variants));
+        variants.insert(target.to_string(), BTreeSet::from([10, 20]));
+        assert!(cds.contains_variant(target, &variants));
     }
 }

--- a/src/graph/transcript.rs
+++ b/src/graph/transcript.rs
@@ -509,7 +509,7 @@ pub(crate) fn transcripts(gff_file: &PathBuf, graph: &PathBuf) -> Result<Vec<Tra
         })?;
         let cds = Cds::new(start, end, phase);
         if !variant_coverage.get(ensp).copied().unwrap_or(false) {
-            let has_variant = cds.contains_variant(&variants);
+            let has_variant = cds.contains_variant(&target, &variants);
             if has_variant {
                 variant_coverage.insert(ensp.to_string(), true);
             }
@@ -681,10 +681,10 @@ mod tests {
     #[test]
     fn transcripts_parses_gff_file_correctly() {
         let gff_content = "\
-            ##gff-version 3
-            chr1\tsource\tCDS\t1\t100\t.\t+\t0\tID=ENSP00000493376
-            chr1\tsource\tCDS\t200\t300\t.\t+\t0\tID=ENSP00000493376
-            chr1\tsource\tCDS\t400\t500\t.\t-\t0\tID=ENSP00000493377
+##gff-version 3
+chr1\tsource\tCDS\t1\t100\t.\t+\t0\tID=ENSP00000493376
+chr1\tsource\tCDS\t200\t300\t.\t+\t0\tID=ENSP00000493376
+chr1\tsource\tCDS\t400\t500\t.\t-\t0\tID=ENSP00000493377
         ";
         let tmp = tempfile::tempdir().unwrap();
         let gff_path = tmp.path().join("test.gff");


### PR DESCRIPTION
This pull request refactors the `contains_variant` method in the `Cds` struct to actually work properly. The method now checks for variants associated with a particular target (such as a chromosome or sequence identifier) rather than searching across all variant sets which held a lot of false positive targets that became empty in the end because there was a variant on that position (but on another target).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Correctly counts variants at coding-region boundaries (inclusive).
  - Avoids false positives by checking variants only within the selected target.
- Refactor
  - Streamlined variant lookup to operate per target for improved efficiency.
- Tests
  - Updated tests to reflect per-target variant checks and boundary cases.
  - Adjusted GFF test input formatting (no change to parsing behavior).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->