### PR TITLE
feat: Add --min-vaf parameter to build subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Builds a full variant graph from VCF files and stores it.
 - `--calls <path>`: Path to the VCF calls file.
 - `--observations <sample=observations.vcf>`: One or more observation files; ensure sample names match those in the calls file.
 - `--min-prob-present <float>`: Minimum probability for a variant to be considered for the graph generation. Defaults to 0.8.
+- `--min-vaf <float>`: Minimum VAF for a variant to be considered in the graph. Needs to be higher for at least one of all given samples. Defaults to 0.05.
 - `--output <path>`: Path to store the generated variant graphs.
 
 **Example:**

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,10 @@ pub(crate) enum Command {
         #[clap(short, long, default_value = "0.8")]
         min_prob_present: f64,
 
+        /// Minimum VAF for a variant to be considered in the graph. Needs to be higher for at least one of all given samples
+        #[clap(short, long, default_value = "0.05")]
+        min_vaf: f32,
+
         /// Path to the output file containing the impact graph
         #[clap(long)]
         output: PathBuf,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,10 +35,9 @@ pub(crate) enum Command {
         #[clap(short, long, default_value = "0.8")]
         min_prob_present: f64,
 
-        /// Minimum VAF for a variant to be considered in the graph. Needs to be higher for at least one of all given samples
-        #[clap(short, long, default_value = "0.05")]
+        /// Minimum VAF for a variant to be kept. The maximum VAF across samples must meet or exceed this threshold.
+        #[clap(long, default_value = "0.05")]
         min_vaf: f32,
-
         /// Path to the output file containing the impact graph
         #[clap(long)]
         output: PathBuf,

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -42,6 +42,7 @@ impl VariantGraph {
         observation_files: &[ObservationFile],
         target: &str,
         min_prob_present: LogProb,
+        min_vaf: f32,
     ) -> Result<VariantGraph> {
         let mut calls_reader = Reader::from_path(calls_file)?;
         let header = calls_reader.header().clone();
@@ -144,6 +145,9 @@ impl VariantGraph {
                 &samples,
                 index,
             );
+            if var_node.max_vaf() < min_vaf {
+                continue;
+            }
             let var_node_index = variant_graph.add_node(var_node);
             let mut ref_node_index = None;
             if last_position != position {
@@ -489,6 +493,7 @@ mod tests {
             &observations,
             "OX512233.1",
             LogProb::from(Prob(0.0)),
+            0.05,
         );
         assert!(variant_graph.is_ok());
     }
@@ -506,6 +511,7 @@ mod tests {
             &observations,
             "not actually in file",
             LogProb::from(Prob(0.0)),
+            0.05,
         );
         assert!(variant_graph.unwrap().is_empty());
     }
@@ -534,6 +540,7 @@ mod tests {
             &observations,
             "OX512233.1",
             LogProb::from(Prob(0.0)),
+            0.00,
         )
         .unwrap();
         variant_graph.graph.add_edge(

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -123,6 +123,15 @@ impl Node {
         (reference_length as i64 - 1) - self.pos
     }
 
+    /// Returns the maximum VAF across all samples
+    pub(crate) fn max_vaf(&self) -> f32 {
+        *self
+            .vaf
+            .values()
+            .max_by(|a, b| a.partial_cmp(b).unwrap())
+            .unwrap_or(&0.0)
+    }
+
     pub(crate) fn reference_amino_acid(
         &self,
         phase: u8,

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -755,4 +755,21 @@ mod tests {
         assert_eq!(format!("{}", var_node), "Var(A) at position 42");
         assert_eq!(format!("{}", ref_node), "Ref at position 99");
     }
+
+    #[test]
+    fn test_node_max_vaf() {
+        let mut vafs = HashMap::new();
+        vafs.insert("A".to_string(), 0.05);
+        vafs.insert("C".to_string(), 0.1);
+        vafs.insert("G".to_string(), 0.02);
+        vafs.insert("T".to_string(), 0.03);
+        let var_node = Node {
+            node_type: NodeType::Var("A".to_string()),
+            vaf: vafs.clone(),
+            probs: EventProbs(Default::default()),
+            pos: 42,
+            index: 0,
+        };
+        assert_eq!(var_node.max_vaf(), 0.1);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ impl Command {
                 calls,
                 observations,
                 min_prob_present,
+                min_vaf,
                 output,
             } => {
                 let targets = get_targets(calls)?;
@@ -63,6 +64,7 @@ impl Command {
                             observations,
                             &target,
                             LogProb::from(Prob(*min_prob_present)),
+                            *min_vaf,
                         )
                         .ok()?;
                         info!(


### PR DESCRIPTION
This pull request introduces a new filter for variant graph generation based on the maximum Variant Allele Frequency (VAF) across samples. The filter ensures that only variants with a sufficiently high VAF in at least one sample are included in the graph. The change is reflected in the CLI, documentation, graph construction logic, and related tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a --min-vaf <float> Build option to filter variants by Variant Allele Frequency (default 0.05); a variant is kept only if at least one sample meets or exceeds the threshold. Works alongside existing --min-prob-present.

- Documentation
  - README updated to describe the new VAF threshold option, default, and usage.

- Tests
  - Tests updated to validate graph construction with different VAF thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->