### PR TITLE
fix: Consider all possible start nodes for path enumeration

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -323,12 +323,10 @@ impl VariantGraph {
     ///     elements, representing the nodes in the order they are visited
     pub(crate) fn paths(&self) -> Vec<HaplotypePath> {
         let mut all_paths = Vec::new();
-        let min_index = self
-            .graph
-            .node_indices()
-            .map(|i| self.graph[i].index)
-            .min()
-            .unwrap();
+        let min_index = match self.graph.node_indices().map(|i| self.graph[i].index).min() {
+            Some(min_index) => min_index,
+            None => return Vec::new(),
+        };
         let start_nodes = self
             .graph
             .node_indices()

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -311,15 +311,15 @@ impl VariantGraph {
         Ok(())
     }
 
-    /// Finds all paths starting from the first two nodes in the graph.
+    /// Finds all paths starting from all nodes with the lowest graph index.
     ///
-    /// This method performs a depth-first search (DFS) starting from the first two nodes
-    /// in the graph. It collects all possible paths, including those that reach leaf nodes
+    /// This method performs a depth-first search (DFS) starting from from every node whose graph index is the minimum index in the graph.
+    /// It collects all possible paths, including those that reach leaf nodes
     /// (nodes with no outgoing edges). The paths are represented as vectors of `NodeIndex`.
     ///
     /// Returns:
     ///     A vector of vectors, where each inner vector represents a path through the graph
-    ///     starting from one of the initial nodes. Each path is a sequence of `NodeIndex`
+    ///     starting from one of the lowest-index start nodes. Each path is a sequence of `NodeIndex`
     ///     elements, representing the nodes in the order they are visited
     pub(crate) fn paths(&self) -> Vec<HaplotypePath> {
         let mut all_paths = Vec::new();

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -323,11 +323,16 @@ impl VariantGraph {
     ///     elements, representing the nodes in the order they are visited
     pub(crate) fn paths(&self) -> Vec<HaplotypePath> {
         let mut all_paths = Vec::new();
+        let min_index = self
+            .graph
+            .node_indices()
+            .map(|i| self.graph[i].index)
+            .min()
+            .unwrap();
         let start_nodes = self
             .graph
             .node_indices()
-            .sorted_by_key(|&i| self.graph[i].index)
-            .take(2)
+            .filter(|&i| self.graph[i].index == min_index)
             .collect::<Vec<_>>();
         for start_node in start_nodes {
             let mut stack = vec![(start_node, vec![start_node])];

--- a/src/graph/transcript.rs
+++ b/src/graph/transcript.rs
@@ -763,7 +763,7 @@ mod tests {
             ],
         )]);
         let rna_paths = transcript.rna(&graph_path, &reference, "s1").unwrap();
-        assert_eq!(rna_paths.len(), 4);
+        assert_eq!(rna_paths.len(), 1);
         assert_eq!(
             rna_paths[0].sequence,
             vec![
@@ -1002,7 +1002,7 @@ chr1\tsource\tCDS\t400\t500\t.\t-\t0\tID=ENSP00000493377
         write_graphs(HashMap::from([("test".to_string(), graph)]), &graph_path).unwrap();
         let reference = HashMap::from([("test".to_string(), vec![b'A', b'T', b'G', b'C'])]);
         let weights = transcript.weights(&graph_path, &reference).unwrap();
-        assert_eq!(weights.len(), 2);
+        assert_eq!(weights.len(), 1);
         assert_eq!(weights[0].len(), 2);
     }
 
@@ -1026,7 +1026,7 @@ chr1\tsource\tCDS\t400\t500\t.\t-\t0\tID=ENSP00000493377
             ],
         )]);
         let weights = transcript.weights(&graph_path, &reference).unwrap();
-        assert_eq!(weights.len(), 4);
+        assert_eq!(weights.len(), 1);
         assert_eq!(weights[0].len(), 4);
     }
 


### PR DESCRIPTION
Fixes any cases when the first variant of a CDS has multiple alternative alleles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved graph path-finding start selection to reduce redundant results and to return no paths for empty graphs.
* **Tests**
  * Updated unit tests to reflect the reduced number of generated paths and weights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->