### PR TITLE
feat: Fetch, store and render variant annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -465,6 +465,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,7 +498,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -500,7 +522,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -589,9 +611,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
@@ -793,6 +815,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,9 +944,9 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cmake"
-version = "0.1.51"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -936,6 +964,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -969,6 +1007,16 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1035,7 +1083,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "libc",
  "parking_lot",
@@ -1048,7 +1096,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "parking_lot",
  "rustix 0.38.41",
 ]
@@ -1297,6 +1345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "editdistancek"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,6 +1537,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,6 +1628,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "genebears"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2c8b8c02bb2df765d057b430e5e2cafb8e9843daa5161c921bc1cbb46c43feb"
+dependencies = [
+ "clap 4.6.1",
+ "duckdb",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.3",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,7 +1675,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1645,7 +1721,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "ignore",
  "walkdir",
 ]
@@ -1848,18 +1924,22 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2091,6 +2171,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +2267,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,10 +2321,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2295,7 +2430,7 @@ dependencies = [
  "cc",
  "flate2",
  "pkg-config",
- "reqwest",
+ "reqwest 0.12.12",
  "serde",
  "serde_json",
  "tar",
@@ -2310,7 +2445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2325,7 +2460,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "libc",
  "redox_syscall",
 ]
@@ -2654,6 +2789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "openssl-src"
 version = "300.4.1+3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,6 +3045,7 @@ dependencies = [
  "csv",
  "duckdb",
  "env_logger",
+ "genebears",
  "itertools 0.14.0",
  "json5",
  "log",
@@ -2914,6 +3056,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tera",
+ "tokio",
  "varlociraptor",
 ]
 
@@ -3038,7 +3181,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2",
+ "socket2 0.5.8",
  "thiserror 2.0.3",
  "tokio",
  "tracing",
@@ -3050,6 +3193,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.2.15",
  "rand 0.8.5",
@@ -3073,7 +3217,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3227,7 +3371,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3310,6 +3454,44 @@ dependencies = [
  "web-sys",
  "webpki-roots 0.26.11",
  "windows-registry",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3451,7 +3633,7 @@ version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -3464,7 +3646,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -3477,12 +3659,25 @@ version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3505,11 +3700,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.14",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -3557,6 +3780,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3567,6 +3799,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3672,6 +3927,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simba"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3732,6 +3997,16 @@ checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4087,8 +4362,10 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
- "socket2",
+ "signal-hook-registry",
+ "socket2 0.5.8",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -4156,6 +4433,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4174,7 +4469,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4450,27 +4757,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
- "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4488,9 +4782,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote 1.0.45",
  "wasm-bindgen-macro-support",
@@ -4498,22 +4792,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
+ "bumpalo",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
@@ -4533,6 +4830,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4600,7 +4906,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4623,7 +4929,7 @@ checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4632,7 +4938,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4642,7 +4948,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -4651,7 +4966,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4660,7 +4975,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4674,19 +4989,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4696,9 +5032,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4714,9 +5062,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4726,9 +5086,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4751,7 +5123,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ csv = "1.4.0"
 log = "0.4.29"
 rayon = "1.12.0"
 env_logger = "0.11.6"
+genebears = "0.2.0"
+tokio = { version = "1", features = ["rt"] }
 
 [dev-dependencies]
 tempfile = "3.27.0"
@@ -36,4 +38,3 @@ lto = "fat"
 
 [lints.rust]
 unused = "allow"
-

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -1,0 +1,66 @@
+use anyhow::Result;
+use bio::bio_types::strand::Strand;
+use genebears::{AnnotateOptions, ClientConfig, GeneBears, Genome, Variant};
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+
+use crate::graph::node::Node;
+use crate::graph::transcript::Transcript;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct Annotation {
+    pub(crate) revel_score: Option<f64>,
+    pub(crate) acmg_score: Option<f64>,
+    pub(crate) spliceai_score: Option<f64>,
+    pub(crate) alphamissense_score: Option<f64>,
+}
+
+impl Annotation {
+    pub(crate) fn from_haplotype(haplotype: &[Node], transcript: &Transcript) -> Result<Self> {
+        let mut variants: Vec<_> = haplotype
+            .iter()
+            .filter(|n| n.node_type.is_variant())
+            .collect();
+        if transcript.strand == Strand::Reverse {
+            variants.reverse();
+        }
+        let in_phase: Vec<&Node> = variants
+            .into_iter()
+            .scan(0i64, |running_fs, node| {
+                let fs = node.frameshift();
+                let in_phase = *running_fs % 3 == 0;
+                *running_fs += fs;
+                Some((node, in_phase))
+            })
+            .filter_map(|(node, in_phase)| in_phase.then_some(node))
+            .collect();
+        let variants = in_phase
+            .iter()
+            .map(|node| {
+                Variant::new(
+                    transcript.target.to_string(),
+                    node.pos as u64,
+                    node.reference_allele.to_string(),
+                    node.alternative_allele.to_string(),
+                )
+            })
+            .collect_vec();
+        let client = GeneBears::new(ClientConfig::default())?;
+        let results = tokio::runtime::Runtime::new()?.block_on(client.annotate_variants(
+            &variants,
+            Genome::Hg38,
+            AnnotateOptions::default(),
+        ))?;
+
+        Ok(Self {
+            revel_score: max_score(results.iter().map(|r| r.revel_score)),
+            acmg_score: max_score(results.iter().map(|r| r.acmg_score)),
+            spliceai_score: max_score(results.iter().map(|r| r.spliceai_max_score)),
+            alphamissense_score: max_score(results.iter().map(|r| r.alphamissense_score)),
+        })
+    }
+}
+
+fn max_score(iter: impl Iterator<Item = Option<f64>>) -> Option<f64> {
+    iter.flatten().reduce(f64::max)
+}

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -16,7 +16,7 @@ pub(crate) struct Annotation {
 }
 
 impl Annotation {
-    pub(crate) fn from_haplotype(haplotype: &[Node], transcript: &Transcript) -> Result<Self> {
+    pub(crate) fn from_haplotype(haplotype: &[Node], transcript: &Transcript, genome_build: Genome) -> Result<Self> {
         let mut variants: Vec<_> = haplotype
             .iter()
             .filter(|n| n.node_type.is_variant())
@@ -48,7 +48,7 @@ impl Annotation {
         let client = GeneBears::new(ClientConfig::default())?;
         let results = tokio::runtime::Runtime::new()?.block_on(client.annotate_variants(
             &variants,
-            Genome::Hg38,
+            genome_build,
             AnnotateOptions::default(),
         ))?;
 

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -16,7 +16,11 @@ pub(crate) struct Annotation {
 }
 
 impl Annotation {
-    pub(crate) fn from_haplotype(haplotype: &[Node], transcript: &Transcript, genome_build: Genome) -> Result<Self> {
+    pub(crate) fn from_haplotype(
+        haplotype: &[Node],
+        transcript: &Transcript,
+        genome_build: Genome,
+    ) -> Result<Self> {
         let mut variants: Vec<_> = haplotype
             .iter()
             .filter(|n| n.node_type.is_variant())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,7 +77,7 @@ pub(crate) enum Command {
         #[clap(long, default_value = "5000")]
         max_cds_length: u64,
 
-        /// Genome build to use for fetching GeneBe annotations. Must be one of `Hg38`, `Hg19` or `T2t.
+        /// Genome build to use for fetching GeneBe annotations. Must be one of `Hg38`, `Hg19` or `T2t`.
         #[clap(long, default_value = "Hg38")]
         genome_build: genebears::Genome,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap_derive::{Parser, Subcommand, ValueEnum};
+use genebears::GeneBears;
 use serde::{Deserialize, Deserializer};
 use std::fmt::Display;
 use std::path::PathBuf;
@@ -75,6 +76,10 @@ pub(crate) enum Command {
         /// Maximum CDS length to consider for processing. Transcripts containing longer CDSs will be ignored with a warning.
         #[clap(long, default_value = "5000")]
         max_cds_length: u64,
+
+        /// Genome build to use for fetching GeneBe annotations. Must be one of `Hg38`, `Hg19` or `T2t.
+        #[clap(long, default_value = "Hg38")]
+        genome_build: genebears::Genome,
     },
     /// Output all distinct peptides from the given features to a fastq file per given CDS in the feature file
     Peptides {

--- a/src/graph/duck.rs
+++ b/src/graph/duck.rs
@@ -1,3 +1,4 @@
+use crate::annotation::Annotation;
 use crate::graph::node::{Node, NodeType};
 use crate::graph::paths::{Cds, Weight};
 use crate::graph::score::EffectScore;
@@ -185,20 +186,26 @@ pub(crate) fn create_scores(output_path: &Path) -> Result<()> {
 
 pub(crate) fn write_scores(
     path: &Path,
-    scores: Vec<(EffectScore, HaplotypeFrequency, Vec<HashMap<String, u32>>)>,
+    scores: Vec<(
+        EffectScore,
+        HaplotypeFrequency,
+        Vec<HashMap<String, u32>>,
+        Annotation,
+    )>,
     transcript: Transcript,
 ) -> Result<()> {
     let mut db = Connection::open(path)?;
     let transaction = db.transaction()?;
-    let mut stmt = transaction.prepare("INSERT INTO scores VALUES (?, ?, ?, ?, ?)")?;
+    let mut stmt = transaction.prepare("INSERT INTO scores VALUES (?, ?, ?, ?, ?, ?)")?;
     let transcript_name = transcript.name();
-    for (score, likelihoods, supporting_reads) in scores {
+    for (score, likelihoods, supporting_reads, annotation) in scores {
         stmt.execute(params![
             transcript_name.as_str(),
             score.score(),
             json5::to_string(&likelihoods)?,
             score.haplotype,
             json5::to_string(&supporting_reads)?,
+            json5::to_string(&annotation)?,
         ])?;
     }
     transaction.commit()?;
@@ -208,11 +215,22 @@ pub(crate) fn write_scores(
 
 pub(crate) fn read_scores(
     path: &Path,
-) -> Result<HashMap<String, Vec<(f64, HaplotypeFrequency, String, Vec<HashMap<String, u32>>)>>> {
+) -> Result<
+    HashMap<
+        String,
+        Vec<(
+            f64,
+            HaplotypeFrequency,
+            String,
+            Vec<HashMap<String, u32>>,
+            Annotation,
+        )>,
+    >,
+> {
     let db = Connection::open(path)?;
     let mut scores = HashMap::new();
     let mut stmt = db.prepare(
-        "SELECT transcript, score, likelihoods, haplotype, supporting_reads FROM scores",
+        "SELECT transcript, score, likelihoods, haplotype, supporting_reads, annotation FROM scores",
     )?;
     let mut rows = stmt.query([])?;
     while let Some(row) = rows.next()? {
@@ -221,11 +239,13 @@ pub(crate) fn read_scores(
         let likelihoods: String = row.get(2)?;
         let haplotype: String = row.get(3)?;
         let supporting_reads: String = row.get(4)?;
+        let annotation: String = row.get(5)?;
         scores.entry(transcript).or_insert(Vec::new()).push((
             score,
             json5::from_str(&likelihoods)?,
             haplotype,
             json5::from_str(&supporting_reads)?,
+            json5::from_str(&annotation)?,
         ));
     }
     db.close().unwrap();

--- a/src/graph/duck.rs
+++ b/src/graph/duck.rs
@@ -177,7 +177,7 @@ pub(crate) fn variants_on_graph(path: &PathBuf) -> Result<HashMap<String, BTreeS
 pub(crate) fn create_scores(output_path: &Path) -> Result<()> {
     let db = Connection::open(output_path)?;
     db.execute(
-        "CREATE TABLE scores (transcript String, score FLOAT, frequencies String, haplotype String, supporting_reads String)",
+        "CREATE TABLE scores (transcript String, score FLOAT, frequencies String, haplotype String, supporting_reads String, annotation String)",
         [],
     )?;
     db.close().unwrap();
@@ -653,7 +653,13 @@ mod tests {
         };
         let frequencies = HashMap::from([("A".to_string(), 0.1), ("C".to_string(), 0.2)]);
         let supporting_reads = vec![HashMap::from([("A".to_string(), 10), ("C".to_string(), 5)])];
-        let scores = vec![(effect_score, frequencies, supporting_reads)];
+        let annotion = Annotation {
+            revel_score: Some(0.8),
+            acmg_score: Some(0.9),
+            spliceai_score: Some(0.7),
+            alphamissense_score: Some(0.6),
+        };
+        let scores = vec![(effect_score, frequencies, supporting_reads, annotion)];
         write_scores(output_path.as_path(), scores, transcript).unwrap();
         let scores = read_scores(output_path.as_path()).unwrap();
         assert_eq!(scores.len(), 1);

--- a/src/graph/duck.rs
+++ b/src/graph/duck.rs
@@ -198,7 +198,7 @@ pub(crate) fn write_scores(
     let transaction = db.transaction()?;
     let mut stmt = transaction.prepare("INSERT INTO scores VALUES (?, ?, ?, ?, ?, ?)")?;
     let transcript_name = transcript.name();
-for (score, frequencies, supporting_reads, annotation) in scores {
+    for (score, frequencies, supporting_reads, annotation) in scores {
         stmt.execute(params![
             transcript_name.as_str(),
             score.score(),

--- a/src/graph/transcript.rs
+++ b/src/graph/transcript.rs
@@ -1,3 +1,4 @@
+use crate::annotation::Annotation;
 use crate::cli::Interval;
 use crate::graph::duck::{feature_graph, variants_on_graph};
 use crate::graph::node::{Node, NodeType};
@@ -279,7 +280,14 @@ impl Transcript {
         reference: &HashMap<String, Vec<u8>>,
         haplotype_metric: HaplotypeMetric,
         distance_metric: DistanceMetric,
-    ) -> Result<Vec<(EffectScore, HaplotypeFrequency, Vec<HashMap<String, u32>>)>> {
+    ) -> Result<
+        Vec<(
+            EffectScore,
+            HaplotypeFrequency,
+            Vec<HashMap<String, u32>>,
+            Annotation,
+        )>,
+    > {
         let haplotypes = self.haplotypes(graph, haplotype_metric)?;
         let mut scores = Vec::with_capacity(haplotypes.len());
         let original_protein = Protein::from_transcript(reference, self)?;
@@ -294,7 +302,8 @@ impl Transcript {
                 realign,
             )?;
             let frequency = haplotype_metric.calculate(&haplotype);
-            scores.push((effect_score, frequency, supporting_reads));
+            let annotation = Annotation::from_haplotype(&haplotype, self)?;
+            scores.push((effect_score, frequency, supporting_reads, annotation));
         }
         Ok(scores)
     }

--- a/src/graph/transcript.rs
+++ b/src/graph/transcript.rs
@@ -12,9 +12,11 @@ use crate::translation::amino_acids::{AminoAcid, Protein};
 use crate::translation::distance::DistanceMetric;
 use crate::utils::fasta::reverse_complement;
 use anyhow::{bail, Result};
+use bio::bio_types::genome;
 use bio::bio_types::strand::Strand;
 use bio::io::gff::{self, Phase};
 use bio::stats::LogProb;
+use genebears::Genome;
 use itertools::Itertools;
 use log::{info, warn};
 use petgraph::adj::NodeIndex;
@@ -280,6 +282,7 @@ impl Transcript {
         reference: &HashMap<String, Vec<u8>>,
         haplotype_metric: HaplotypeMetric,
         distance_metric: DistanceMetric,
+        genome_build: Genome,
     ) -> Result<
         Vec<(
             EffectScore,
@@ -302,7 +305,7 @@ impl Transcript {
                 realign,
             )?;
             let frequency = haplotype_metric.calculate(&haplotype);
-            let annotation = Annotation::from_haplotype(&haplotype, self)?;
+            let annotation = Annotation::from_haplotype(&haplotype, self, genome_build)?;
             scores.push((effect_score, frequency, supporting_reads, annotation));
         }
         Ok(scores)

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,7 @@ impl Command {
                             &reference_genome,
                             *haplotype_metric,
                             *distance_metric,
+                            *genome_build,
                         )?;
                         info!(
                             "Writing scores for {} different haplotypes for transcript {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use rayon::ThreadPoolBuilder;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+mod annotation;
 mod cli;
 mod graph;
 mod impact;
@@ -89,6 +90,7 @@ impl Command {
                 haplotype_metric,
                 output,
                 max_cds_length,
+                genome_build,
             } => {
                 create_scores(output)?;
                 info!("Reading reference genome from {reference:?}");

--- a/src/show/mod.rs
+++ b/src/show/mod.rs
@@ -254,7 +254,8 @@ mod tests {
                 vec![HashMap::from([
                     ("A".to_string(), 10u32),
                     ("C".to_string(), 5u32),
-                ])],annotion
+                ])],
+                annotion,
             )],
         )]);
         render_scores(&output_path, &scores).unwrap();

--- a/src/show/mod.rs
+++ b/src/show/mod.rs
@@ -76,7 +76,10 @@ pub(crate) fn render_html_paths(
 }
 
 /// Writes given per-haplotype scores into a single TSV file with the columns:
-/// `transcript`, `score`, and two columns per sample containing the frequency and supporting read information. Each row corresponds to one (score, per-sample) pair for a given transcript.
+/// `transcript`, `score`, `haplotype`, annotation score columns (`revel_score`,
+/// `acmg_score`, `spliceai_score`, `alphamissense_score`) and two columns
+/// per sample containing the frequency and supporting read information. Each row
+/// corresponds to one (score, per-sample) pair for a given transcript.
 ///
 /// # Arguments
 ///

--- a/src/show/mod.rs
+++ b/src/show/mod.rs
@@ -1,3 +1,4 @@
+use crate::annotation::Annotation;
 use crate::graph::paths::{Cds, Weight};
 use crate::graph::score::HaplotypeFrequency;
 use anyhow::anyhow;
@@ -83,7 +84,16 @@ pub(crate) fn render_html_paths(
 /// * `scores` - A reference to a `HashMap` that holds the scores, likelihoods, and haplotypes for each transcript.
 pub(crate) fn render_scores(
     output_path: &PathBuf,
-    scores: &HashMap<String, Vec<(f64, HaplotypeFrequency, String, Vec<HashMap<String, u32>>)>>,
+    scores: &HashMap<
+        String,
+        Vec<(
+            f64,
+            HaplotypeFrequency,
+            String,
+            Vec<HashMap<String, u32>>,
+            Annotation,
+        )>,
+    >,
 ) -> Result<()> {
     let mut wtr = WriterBuilder::new()
         .delimiter(b'\t')
@@ -94,7 +104,7 @@ pub(crate) fn render_scores(
         .flat_map(|scores| {
             scores
                 .iter()
-                .flat_map(|(_, sample_scores, _, _)| sample_scores.keys().cloned())
+                .flat_map(|(_, sample_scores, _, _, _)| sample_scores.keys().cloned())
         })
         .unique()
         .collect();
@@ -103,17 +113,33 @@ pub(crate) fn render_scores(
         "transcript".to_string(),
         "score".to_string(),
         "haplotype".to_string(),
+        "revel_score".to_string(),
+        "acmg_score".to_string(),
+        "spliceai_score".to_string(),
+        "alphamissense_score".to_string(),
     ];
     headers.extend(samples.iter().map(|s| format!("{}:frequency", s)));
     headers.extend(samples.iter().map(|s| format!("{}:supporting_reads", s)));
     wtr.write_record(headers)?;
 
     for (transcript, hap_scores) in scores {
-        for (score_val, sample_scores, haplotype, supporting_reads) in hap_scores {
+        for (score_val, sample_scores, haplotype, supporting_reads, annotation) in hap_scores {
             let mut row = vec![
                 transcript.to_string(),
                 score_val.to_string(),
                 haplotype.to_string(),
+                annotation
+                    .revel_score
+                    .map_or("".to_string(), |s| s.to_string()),
+                annotation
+                    .acmg_score
+                    .map_or("".to_string(), |s| s.to_string()),
+                annotation
+                    .spliceai_score
+                    .map_or("".to_string(), |s| s.to_string()),
+                annotation
+                    .alphamissense_score
+                    .map_or("".to_string(), |s| s.to_string()),
             ];
             for sample in &samples {
                 let val = sample_scores.get(sample).ok_or_else(|| {

--- a/src/show/mod.rs
+++ b/src/show/mod.rs
@@ -239,6 +239,12 @@ mod tests {
     fn test_render_scores() {
         let temp_dir = tempfile::tempdir().unwrap();
         let output_path = temp_dir.keep().join("scores.tsv");
+        let annotion = Annotation {
+            revel_score: Some(0.8),
+            acmg_score: Some(0.9),
+            spliceai_score: Some(0.7),
+            alphamissense_score: Some(0.6),
+        };
         let scores = HashMap::from([(
             "chr1:some feature".to_string(),
             vec![(
@@ -248,7 +254,7 @@ mod tests {
                 vec![HashMap::from([
                     ("A".to_string(), 10u32),
                     ("C".to_string(), 5u32),
-                ])],
+                ])],annotion
             )],
         )]);
         render_scores(&output_path, &scores).unwrap();


### PR DESCRIPTION
This PR adds a new `Annotation` struct with usage across transcript, duck, and show modules and serializes annotations into the scores DB (new annotation column). It also includes the annotation fields in the output (revel, acmg, spliceai, alphamissense) and adds genebears and tokio deps and a new CLI `--genome-build` option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Variant annotation scoring added: REVEL, ACMG, SpliceAI and AlphaMissense scores are now computed and included with results.
  * New CLI option to select genome build for annotations (default: Hg38).
  * Result output extended with new columns for annotation scores; missing values are emitted as empty fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->