### PR TITLE
fix: Avoid false ref support in multi-allelic sites

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -204,6 +204,23 @@ impl VariantGraph {
             target: target.to_string(),
         };
 
+        // For each (sample, fragment_id), if this fragment supports
+        // any variant node at position P, remove its ref node entries at position P.
+        // This fixes false ref support from normalized multi-allelic sites where a
+        // fragment supporting alt allele B is incorrectly recorded as ref support
+        // when processing alt allele A at the same position.
+        for nodes in supporting_reads.values_mut() {
+            let variant_positions: HashSet<i64> = nodes
+                .iter()
+                .filter(|&&n| variant_graph.graph[n].node_type == NodeType::Variant)
+                .map(|&n| variant_graph.graph[n].pos)
+                .collect();
+            nodes.retain(|&n| {
+                variant_graph.graph[n].node_type != NodeType::Reference
+                    || !variant_positions.contains(&variant_graph.graph[n].pos)
+            });
+        }
+
         variant_graph.connect_consecutive_positions();
         variant_graph.add_read_support(&supporting_reads)?;
 


### PR DESCRIPTION
This PR makes predictosaurus compute variant positions per fragment and remove reference node entries at those positions before connecting positions and adding read support. Fixes false ref support in multi-allelic sites coming from normalized bcfs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of reference variant attribution in graph construction by correctly handling cases where a sequencing fragment supports both reference and variant nodes, particularly in multi-allelic variant analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->