### PR TITLE
fix: Fix default value for --genome-build parameter

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,8 +77,8 @@ pub(crate) enum Command {
         #[clap(long, default_value = "5000")]
         max_cds_length: u64,
 
-        /// Genome build to use for fetching GeneBe annotations. Must be one of `Hg38`, `Hg19` or `T2t`.
-        #[clap(long, default_value = "Hg38")]
+        /// Genome build to use for fetching GeneBe annotations. Must be one of `hg38`, `hg19` or `t2t`.
+        #[clap(long, default_value = "hg38")]
         genome_build: genebears::Genome,
     },
     /// Output all distinct peptides from the given features to a fastq file per given CDS in the feature file


### PR DESCRIPTION
This pull request fixes
```bash
error: invalid value 'Hg38' for '--genome-build <GENOME_BUILD>'
  [possible values: hg38, hg19, t2t]

  tip: a similar value exists: 'hg38'

For more information, try '--help'.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Standardized genome identifier format in the Process command to lowercase (hg38, hg19, t2t). Previously accepted title-case identifiers (Hg38, Hg19, T2t) are no longer supported. Default genome is now hg38.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->