### PR TITLE
feat: Add HGVS notation option and store both forms

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -129,6 +129,10 @@ pub(crate) enum Command {
         #[clap(short, long)]
         input: PathBuf,
 
+        /// Format of the haplotype notation to use in the output. Must be one of `hgvsg` or `hgvsc`.
+        #[clap(short, long, default_value = "hgvsg")]
+        notation: HgvsNotation,
+
         /// Path to the output TSV file containing the predicted scores per transcript.
         #[clap(short, long)]
         output: PathBuf,
@@ -188,6 +192,13 @@ pub(crate) enum Format {
     Html,
     Tsv,
     Vega,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, Default)]
+pub enum HgvsNotation {
+    #[default]
+    Hgvsg,
+    Hgvsc,
 }
 
 #[derive(Debug, Clone)]

--- a/src/graph/duck.rs
+++ b/src/graph/duck.rs
@@ -1,4 +1,5 @@
 use crate::annotation::Annotation;
+use crate::cli::HgvsNotation;
 use crate::graph::node::{Node, NodeType};
 use crate::graph::paths::{Cds, Weight};
 use crate::graph::score::EffectScore;
@@ -177,7 +178,7 @@ pub(crate) fn variants_on_graph(path: &PathBuf) -> Result<HashMap<String, BTreeS
 pub(crate) fn create_scores(output_path: &Path) -> Result<()> {
     let db = Connection::open(output_path)?;
     db.execute(
-        "CREATE TABLE scores (transcript String, score FLOAT, frequencies String, haplotype String, supporting_reads String, annotation String)",
+        "CREATE TABLE scores (transcript String, score FLOAT, frequencies String, hgvsc String, hgvsg String, supporting_reads String, annotation String)",
         [],
     )?;
     db.close().unwrap();
@@ -196,14 +197,15 @@ pub(crate) fn write_scores(
 ) -> Result<()> {
     let mut db = Connection::open(path)?;
     let transaction = db.transaction()?;
-    let mut stmt = transaction.prepare("INSERT INTO scores VALUES (?, ?, ?, ?, ?, ?)")?;
+    let mut stmt = transaction.prepare("INSERT INTO scores VALUES (?, ?, ?, ?, ?, ?, ?)")?;
     let transcript_name = transcript.name();
     for (score, frequencies, supporting_reads, annotation) in scores {
         stmt.execute(params![
             transcript_name.as_str(),
             score.score(),
             json5::to_string(&frequencies)?,
-            score.haplotype,
+            score.hgvsc,
+            score.hgvsg,
             json5::to_string(&supporting_reads)?,
             json5::to_string(&annotation)?,
         ])?;
@@ -215,6 +217,7 @@ pub(crate) fn write_scores(
 
 pub(crate) fn read_scores(
     path: &Path,
+    notation: HgvsNotation
 ) -> Result<
     HashMap<
         String,
@@ -230,16 +233,25 @@ pub(crate) fn read_scores(
     let db = Connection::open(path)?;
     let mut scores = HashMap::new();
     let mut stmt = db.prepare(
-        "SELECT transcript, score, frequencies, haplotype, supporting_reads, annotation FROM scores",
+        "SELECT transcript, score, frequencies, hgvsc, hgvsg, supporting_reads, annotation FROM scores",
     )?;
     let mut rows = stmt.query([])?;
     while let Some(row) = rows.next()? {
         let transcript = row.get(0)?;
         let score = row.get(1)?;
         let frequencies: String = row.get(2)?;
-        let haplotype: String = row.get(3)?;
-        let supporting_reads: String = row.get(4)?;
-        let annotation: String = row.get(5)?;
+        let hgvsc: String = row.get(3)?;
+        let hgvsg: String = row.get(4)?;
+        let supporting_reads: String = row.get(5)?;
+        let annotation: String = row.get(6)?;
+        let haplotype = match notation {
+            HgvsNotation::Hgvsc => {
+                hgvsc
+            }
+            HgvsNotation::Hgvsg => {
+                hgvsg
+            }
+        };
         scores.entry(transcript).or_insert(Vec::new()).push((
             score,
             json5::from_str(&frequencies)?,
@@ -649,7 +661,8 @@ mod tests {
             altered_protein: p2,
             distance_metric: DistanceMetric::Epstein,
             realign: false,
-            haplotype: "c.[100A>G;105C>T]".to_string(),
+            hgvsc: "c.[100A>G;105C>T]".to_string(),
+            hgvsg: "g.[100A>G;105C>T]".to_string(),
         };
         let frequencies = HashMap::from([("A".to_string(), 0.1), ("C".to_string(), 0.2)]);
         let supporting_reads = vec![HashMap::from([("A".to_string(), 10), ("C".to_string(), 5)])];
@@ -661,7 +674,7 @@ mod tests {
         };
         let scores = vec![(effect_score, frequencies, supporting_reads, annotion)];
         write_scores(output_path.as_path(), scores, transcript).unwrap();
-        let scores = read_scores(output_path.as_path()).unwrap();
+        let scores = read_scores(output_path.as_path(), HgvsNotation::Hgvsc).unwrap();
         assert_eq!(scores.len(), 1);
         assert!((scores.get("chr1:some feature").unwrap()[0].0 - 0.03999999910593033).abs() < 1e-6);
         assert!(

--- a/src/graph/duck.rs
+++ b/src/graph/duck.rs
@@ -217,7 +217,7 @@ pub(crate) fn write_scores(
 
 pub(crate) fn read_scores(
     path: &Path,
-    notation: HgvsNotation
+    notation: HgvsNotation,
 ) -> Result<
     HashMap<
         String,
@@ -245,12 +245,8 @@ pub(crate) fn read_scores(
         let supporting_reads: String = row.get(5)?;
         let annotation: String = row.get(6)?;
         let haplotype = match notation {
-            HgvsNotation::Hgvsc => {
-                hgvsc
-            }
-            HgvsNotation::Hgvsg => {
-                hgvsg
-            }
+            HgvsNotation::Hgvsc => hgvsc,
+            HgvsNotation::Hgvsg => hgvsg,
         };
         scores.entry(transcript).or_insert(Vec::new()).push((
             score,

--- a/src/graph/score.rs
+++ b/src/graph/score.rs
@@ -35,17 +35,6 @@ impl EffectScore {
             .iter()
             .filter(|n| n.node_type.is_variant())
             .collect();
-        if transcript.strand == Strand::Reverse {
-            variants.reverse();
-        }
-        let hgvsc = format!(
-            "c.[{}]",
-            variants
-                .iter()
-                .map(|n| n.hgvs_notation(transcript))
-                .collect::<Vec<_>>()
-                .join(";")
-        );
         let hgvsg = format!(
             "g.[{}]",
             variants
@@ -56,6 +45,17 @@ impl EffectScore {
                     n.reference_allele,
                     n.alternative_allele
                 ))
+                .collect::<Vec<_>>()
+                .join(";")
+        );
+        if transcript.strand == Strand::Reverse {
+            variants.reverse();
+        }
+        let hgvsc = format!(
+            "c.[{}]",
+            variants
+                .iter()
+                .map(|n| n.hgvs_notation(transcript))
                 .collect::<Vec<_>>()
                 .join(";")
         );

--- a/src/graph/score.rs
+++ b/src/graph/score.rs
@@ -50,7 +50,12 @@ impl EffectScore {
             "g.[{}]",
             variants
                 .iter()
-                .map(|n| format!("{}{}>{}", n.pos + 1, n.reference_allele, n.alternative_allele))
+                .map(|n| format!(
+                    "{}{}>{}",
+                    n.pos + 1,
+                    n.reference_allele,
+                    n.alternative_allele
+                ))
                 .collect::<Vec<_>>()
                 .join(";")
         );

--- a/src/graph/score.rs
+++ b/src/graph/score.rs
@@ -17,7 +17,8 @@ pub struct EffectScore {
     pub altered_protein: Protein,
     pub distance_metric: DistanceMetric,
     pub realign: bool,
-    pub haplotype: String,
+    pub hgvsc: String,
+    pub hgvsg: String,
 }
 
 impl EffectScore {
@@ -37,11 +38,19 @@ impl EffectScore {
         if transcript.strand == Strand::Reverse {
             variants.reverse();
         }
-        let haplotype = format!(
+        let hgvsc = format!(
             "c.[{}]",
             variants
                 .iter()
                 .map(|n| n.hgvs_notation(transcript))
+                .collect::<Vec<_>>()
+                .join(";")
+        );
+        let hgvsg = format!(
+            "g.[{}]",
+            variants
+                .iter()
+                .map(|n| format!("{}{}>{}", n.pos + 1, n.reference_allele, n.alternative_allele))
                 .collect::<Vec<_>>()
                 .join(";")
         );
@@ -50,7 +59,8 @@ impl EffectScore {
             altered_protein,
             distance_metric,
             realign,
-            haplotype,
+            hgvsc,
+            hgvsg,
         })
     }
 
@@ -323,7 +333,8 @@ mod tests {
             altered_protein: p2,
             distance_metric: DistanceMetric::Epstein,
             realign: false,
-            haplotype: "c.[100A>G;105C>T]".to_string(),
+            hgvsc: "c.[100A>G;105C>T]".to_string(),
+            hgvsg: "g.[100A>G;105C>T]".to_string(),
         };
         assert!(score.score().abs() < 1e-6);
     }
@@ -337,7 +348,8 @@ mod tests {
             altered_protein: p2,
             distance_metric: DistanceMetric::Epstein,
             realign: false,
-            haplotype: "c.[100A>G;105C>T]".to_string(),
+            hgvsc: "c.[100A>G;105C>T]".to_string(),
+            hgvsg: "g.[100A>G;105C>T]".to_string(),
         };
         // Distance between Leucine and Valine is 0.03 / 2 since len = 2
         assert!((score.score() - 0.015).abs() < 1e-6)
@@ -360,7 +372,8 @@ mod tests {
             altered_protein: p2,
             distance_metric: DistanceMetric::Epstein,
             realign: false,
-            haplotype: "c.[100A>G;105C>T]".to_string(),
+            hgvsc: "c.[100A>G;105C>T]".to_string(),
+            hgvsg: "g.[100A>G;105C>T]".to_string(),
         };
         assert!((score.score() - (2.0 / 3.0)).abs() < 1e-6)
     }
@@ -378,7 +391,8 @@ mod tests {
             altered_protein: p2,
             distance_metric: DistanceMetric::Epstein,
             realign: true,
-            haplotype: "c.[100A>G;105C>T]".to_string(),
+            hgvsc: "c.[100A>G;105C>T]".to_string(),
+            hgvsg: "g.[100A>G;105C>T]".to_string(),
         };
         assert!((score.score() - 0.5).abs() < 1e-6)
     }
@@ -405,7 +419,8 @@ mod tests {
             altered_protein: p2,
             distance_metric: DistanceMetric::Epstein,
             realign: true,
-            haplotype: "c.[100A>G;105C>T]".to_string(),
+            hgvsc: "c.[100A>G;105C>T]".to_string(),
+            hgvsg: "g.[100A>G;105C>T]".to_string(),
         };
         assert!((score.score() - 0.2).abs() < 1e-6)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,11 @@ impl Command {
                 info!("Writing peptides to {output:?}");
                 write_peptides(peptides, output)?;
             }
-            Command::Plot { input, notation, output } => {
+            Command::Plot {
+                input,
+                notation,
+                output,
+            } => {
                 if let Some(parent) = output.parent() {
                     create_output_dir(parent)?;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,11 +157,11 @@ impl Command {
                 info!("Writing peptides to {output:?}");
                 write_peptides(peptides, output)?;
             }
-            Command::Plot { input, output } => {
+            Command::Plot { input, notation, output } => {
                 if let Some(parent) = output.parent() {
                     create_output_dir(parent)?;
                 }
-                let scores = read_scores(input)?;
+                let scores = read_scores(input, *notation)?;
                 render_scores(output, &scores)?;
             }
         }


### PR DESCRIPTION
This PR adds an `HgvsNotation` enum and CLI `--notation` flag. It makes predictosaurus persist both hgvsc and hgvsg columns in the scores DB. `EffectScore` now contains both hgvsc and hgvsg and `read_scores` accepts a notation argument to select which value to return for the haplotype column in the tsv output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--notation` parameter to the Plot command for selecting haplotype notation format. Choose between hgvsg (default) and hgvsc formats to customize how results are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->