### PR TITLE
fix: Prune edges without evidence early

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,9 +73,10 @@ pub(crate) enum Command {
         #[clap(short, long)]
         output: PathBuf,
 
-        /// Maximum variants per transcript to consider for processing. Transcripts containing more variants will be ignored with a warning.
-        #[clap(long, default_value = "18")]
-        max_variants_per_transcript: usize,
+        /// Maximum number of haplotypes to consider per transcript. Haplotypes are ranked by their minimum read support across all edges (excluding zero-support edges, which indicate uncertain phasing).
+        /// Only the top-k haplotypes are retained. Lower values reduce runtime and memory usage at the cost of potentially missing low-confidence haplotypes.
+        #[clap(long, default_value = "50")]
+        max_haplotypes_per_transcript: usize,
 
         /// Genome build to use for fetching GeneBe annotations. Must be one of `hg38`, `hg19` or `t2t`.
         #[clap(long, default_value = "hg38")]

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -251,7 +251,46 @@ impl VariantGraph {
         info!("Adding read support for target {target}.");
         variant_graph.add_read_support(&supporting_reads, &possible_node_pairs)?;
 
+        info!("Removing edges without evidence for target {target}.");
+        variant_graph.prune_edges_without_evidence(&nodes_by_index);
+
         Ok(variant_graph)
+    }
+
+    pub(crate) fn prune_edges_without_evidence(&mut self, nodes_by_index: &HashMap<u32, Vec<NodeIndex>>) -> Result<()> {
+        let sorted_positions: Vec<_> = nodes_by_index.keys().sorted().collect();
+        for (&idx_a, &idx_b) in sorted_positions.iter().tuple_windows() {
+            // Check all edges between nodes at idx_a and idx_b
+            // Remove all edges without read support if and only if there is at least one edge with read support between any nodes at idx_a and idx_b
+            let mut has_evidence = false;
+            for &node_a in &nodes_by_index[idx_a] {
+                for &node_b in &nodes_by_index[idx_b] {
+                    if let Some(edge) = self.graph.find_edge(node_a, node_b) {
+                        let edge_weight = self.graph.edge_weight(edge).unwrap();
+                        if edge_weight.supporting_reads.values().sum::<u32>() > 0 {
+                            has_evidence = true;
+                            break;
+                        }
+                    }
+                }
+                if has_evidence {
+                    break;
+                }
+            }
+            if has_evidence {
+                for &node_a in &nodes_by_index[idx_a] {
+                    for &node_b in &nodes_by_index[idx_b] {
+                        if let Some(edge) = self.graph.find_edge(node_a, node_b) {
+                            let edge_weight = self.graph.edge_weight(edge).unwrap();
+                            if edge_weight.supporting_reads.values().sum::<u32>() == 0 {
+                                self.graph.remove_edge(edge);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 
     pub(crate) fn connect_consecutive_positions(

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -252,7 +252,7 @@ impl VariantGraph {
         variant_graph.add_read_support(&supporting_reads, &possible_node_pairs)?;
 
         info!("Removing edges without evidence for target {target}.");
-        variant_graph.prune_edges_without_evidence(&nodes_by_index);
+        variant_graph.prune_edges_without_evidence(&nodes_by_index)?;
 
         Ok(variant_graph)
     }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -469,6 +469,13 @@ impl VariantGraph {
             None => return vec![],
         };
 
+        let max_index = self
+            .graph
+            .node_indices()
+            .map(|i| self.graph[i].index)
+            .max()
+            .unwrap_or(0);
+
         let start_nodes: Vec<NodeIndex> = self
             .graph
             .node_indices()
@@ -550,6 +557,10 @@ impl VariantGraph {
         complete
             .into_iter()
             .map(|(path, _, _)| HaplotypePath(path))
+            .filter(|path| {
+                let last_node = *path.0.last().unwrap();
+                self.graph[last_node].index == max_index
+            })
             .unique()
             .collect()
     }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -553,14 +553,14 @@ impl VariantGraph {
         }
 
         complete.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)));
+        complete.retain(|(path, _, _)| {
+            let last_node = *path.last().unwrap();
+            self.graph[last_node].index == max_index
+        });
         complete.truncate(k);
         complete
             .into_iter()
             .map(|(path, _, _)| HaplotypePath(path))
-            .filter(|path| {
-                let last_node = *path.0.last().unwrap();
-                self.graph[last_node].index == max_index
-            })
             .unique()
             .collect()
     }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -257,7 +257,10 @@ impl VariantGraph {
         Ok(variant_graph)
     }
 
-    pub(crate) fn prune_edges_without_evidence(&mut self, nodes_by_index: &HashMap<u32, Vec<NodeIndex>>) -> Result<()> {
+    pub(crate) fn prune_edges_without_evidence(
+        &mut self,
+        nodes_by_index: &HashMap<u32, Vec<NodeIndex>>,
+    ) -> Result<()> {
         let sorted_positions: Vec<_> = nodes_by_index.keys().sorted().collect();
         for (&idx_a, &idx_b) in sorted_positions.iter().tuple_windows() {
             // Check all edges between nodes at idx_a and idx_b

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -463,6 +463,104 @@ impl VariantGraph {
             .collect()
     }
 
+    pub(crate) fn top_k_paths(&self, k: usize) -> Vec<HaplotypePath> {
+        let min_index = match self.graph.node_indices().map(|i| self.graph[i].index).min() {
+            Some(m) => m,
+            None => return vec![],
+        };
+
+        let start_nodes: Vec<NodeIndex> = self
+            .graph
+            .node_indices()
+            .filter(|&i| self.graph[i].index == min_index)
+            .collect();
+
+        // (path, no_zero_edges, min_nonzero_reads)
+        type ScoredPath = (Vec<NodeIndex>, bool, u32);
+
+        let score = |path: &[NodeIndex]| -> (bool, u32) {
+            let mut min_nz = u32::MAX;
+            let mut has_zero = false;
+            for w in path.windows(2) {
+                if let Some(e) = self
+                    .graph
+                    .find_edge(w[0], w[1])
+                    .or_else(|| self.graph.find_edge(w[1], w[0]))
+                {
+                    let total: u32 = self
+                        .graph
+                        .edge_weight(e)
+                        .unwrap()
+                        .supporting_reads
+                        .values()
+                        .sum();
+                    if total == 0 {
+                        has_zero = true;
+                    } else {
+                        min_nz = min_nz.min(total);
+                    }
+                }
+            }
+            let min_nz = if min_nz == u32::MAX { 0 } else { min_nz };
+            (!has_zero, min_nz)
+        };
+
+        let mut beam: Vec<ScoredPath> = start_nodes
+            .iter()
+            .map(|&n| (vec![n], true, u32::MAX))
+            .collect();
+
+        let mut complete: Vec<ScoredPath> = Vec::new();
+
+        while !beam.is_empty() {
+            let mut next_beam: Vec<ScoredPath> = Vec::new();
+
+            for (path, _, _) in beam {
+                let current = *path.last().unwrap();
+                let neighbors: Vec<NodeIndex> = self
+                    .graph
+                    .neighbors(current)
+                    .filter(|&n| self.graph[n].index > self.graph[current].index)
+                    .filter(|&n| !path.contains(&n))
+                    .collect();
+
+                if neighbors.is_empty() {
+                    if self.graph[current].pos != -1 {
+                        let (no_zero, min_nz) = score(&path);
+                        complete.push((path, no_zero, min_nz));
+                    }
+                } else {
+                    for neighbor in neighbors {
+                        let mut new_path = path.clone();
+                        new_path.push(neighbor);
+                        let (no_zero, min_nz) = score(&new_path);
+                        next_beam.push((new_path, no_zero, min_nz));
+                    }
+                }
+            }
+
+            // Keep only top-k in beam
+            next_beam.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)));
+            next_beam.truncate(k);
+            beam = next_beam;
+        }
+
+        complete.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)));
+        complete.truncate(k);
+        complete
+            .into_iter()
+            .map(|(path, _, _)| HaplotypePath(path))
+            .unique()
+            .collect()
+    }
+
+    pub(crate) fn reverse_top_k_paths(&self, k: usize) -> Vec<HaplotypePath> {
+        self.top_k_paths(k)
+            .iter()
+            .map(|path| HaplotypePath(path.0.iter().rev().cloned().collect()))
+            .collect()
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.graph.node_count() == 0
     }
@@ -704,7 +802,7 @@ mod tests {
             },
         );
         let paths = variant_graph.paths();
-        assert_eq!(paths.len(), 16);
+        assert_eq!(paths.len(), 4);
     }
 
     #[test]

--- a/src/graph/transcript.rs
+++ b/src/graph/transcript.rs
@@ -147,7 +147,7 @@ impl Transcript {
     fn haplotypes(
         &self,
         graph: &PathBuf,
-        max_variant_nodes: usize,
+        max_haplotypes: usize,
     ) -> Result<Vec<(Vec<Node>, Vec<HashMap<String, u32>>)>> {
         let graph = match feature_graph(
             graph.to_owned(),
@@ -173,16 +173,6 @@ impl Transcript {
             .filter(|&i| in_cds(graph.graph[i].pos))
             .count();
 
-        if variant_count > max_variant_nodes {
-            warn!(
-                "Skipping transcript {} with {} variant nodes (max: {})",
-                self.name(),
-                variant_count,
-                max_variant_nodes
-            );
-            return Ok(vec![]);
-        }
-
         info!(
             "Calculating paths for transcript {} with {} variant nodes",
             self.name(),
@@ -190,12 +180,12 @@ impl Transcript {
         );
 
         let raw_paths = match self.strand {
-            Strand::Forward => graph.paths(),
-            Strand::Reverse => graph.reverse_paths(),
+            Strand::Forward => graph.top_k_paths(max_haplotypes),
+            Strand::Reverse => graph.reverse_top_k_paths(max_haplotypes),
             Strand::Unknown => bail!("Strand is unknown for transcript {}", self.name()),
         };
 
-        let haplotypes: Vec<(Vec<Node>, Vec<HashMap<String, u32>>)> = raw_paths
+        Ok(raw_paths
             .iter()
             .map(|p| {
                 let nodes: Vec<Node> =
@@ -239,29 +229,6 @@ impl Transcript {
 
                 (filtered_nodes, filtered_edges)
             })
-            .collect();
-
-        let max_edges = haplotypes.iter().map(|(_, e)| e.len()).max().unwrap_or(0);
-
-        let max_reads_per_edge: Vec<u32> = (0..max_edges)
-            .map(|i| {
-                haplotypes
-                    .iter()
-                    .filter_map(|(_, edges)| edges.get(i))
-                    .map(|e| e.values().sum::<u32>())
-                    .max()
-                    .unwrap_or(0)
-            })
-            .collect();
-
-        Ok(haplotypes
-            .into_iter()
-            .filter(|(_, edges)| {
-                edges.iter().enumerate().all(|(i, edge)| {
-                    let total: u32 = edge.values().sum();
-                    total > 0 || max_reads_per_edge[i] == 0
-                })
-            })
             .collect())
     }
 
@@ -270,7 +237,7 @@ impl Transcript {
         graph: &PathBuf,
         reference: &HashMap<String, Vec<u8>>,
         haplotype_metric: HaplotypeMetric,
-        max_variant_nodes: usize,
+        max_haplotypes: usize,
         distance_metric: DistanceMetric,
         genome_build: Genome,
     ) -> Result<
@@ -281,7 +248,7 @@ impl Transcript {
             Annotation,
         )>,
     > {
-        let haplotypes = self.haplotypes(graph, max_variant_nodes)?;
+        let haplotypes = self.haplotypes(graph, max_haplotypes)?;
         let mut scores = Vec::with_capacity(haplotypes.len());
         let original_protein = Protein::from_transcript(reference, self)?;
         for (haplotype, supporting_reads) in haplotypes {

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ impl Command {
                 distance_metric,
                 haplotype_metric,
                 output,
-                max_variants_per_transcript,
+                max_haplotypes_per_transcript,
                 genome_build,
             } => {
                 create_scores(output)?;
@@ -110,7 +110,7 @@ impl Command {
                             graph,
                             &reference_genome,
                             *haplotype_metric,
-                            *max_variants_per_transcript,
+                            *max_haplotypes_per_transcript,
                             *distance_metric,
                             *genome_build,
                         )?;


### PR DESCRIPTION
This pull request refactors how haplotypes are selected and processed per transcript, shifting from a variant-based limit to a haplotype-based top-k selection. It introduces new logic to efficiently rank and filter haplotypes by read support, improving both performance and biological relevance. Additionally, it prunes unsupported edges from the variant graph and updates related code paths and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented top-k haplotype selection using beam-search for improved efficiency and runtime/memory optimization.

* **Bug Fixes**
  * Removed edges lacking read evidence from graph construction to ensure data integrity.

* **Chores**
  * Renamed CLI parameter `max_variants_per_transcript` to `max_haplotypes_per_transcript` (default: 50) to reflect updated haplotype-selection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fxwiegand/predictosaurus/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->