### PR TITLE
fix: Use shared GeneBears client with lock

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -7,6 +7,7 @@ use itertools::Itertools;
 use log::warn;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
 use crate::graph::node::Node;
 use crate::graph::transcript::Transcript;
@@ -24,7 +25,7 @@ impl Annotation {
         haplotype: &[Node],
         transcript: &Transcript,
         genome_build: Genome,
-        genebe_cache: &Option<PathBuf>,
+        genebe_client: &Arc<Mutex<GeneBears>>,
     ) -> Result<Self> {
         let mut variants: Vec<_> = haplotype
             .iter()
@@ -54,19 +55,17 @@ impl Annotation {
                 )
             })
             .collect_vec();
-        let config = if let Some(cache) = genebe_cache {
-            ClientConfig::default().with_cache(cache)
-        } else {
-            ClientConfig::default()
-        };
-        let client = GeneBears::new(config)?;
         let rt = tokio::runtime::Runtime::new()?;
 
-        let results = rt.block_on(client.annotate_variants(
-            &variants,
-            genome_build,
-            AnnotateOptions::default(),
-        ));
+        let results = {
+            let client = genebe_client.lock().unwrap();
+            let rt = tokio::runtime::Runtime::new()?;
+            rt.block_on(client.annotate_variants(
+                &variants,
+                genome_build,
+                AnnotateOptions::default(),
+            ))
+        };
 
         let results = match results {
             Ok(r) => r,

--- a/src/graph/transcript.rs
+++ b/src/graph/transcript.rs
@@ -16,6 +16,7 @@ use bio::bio_types::genome;
 use bio::bio_types::strand::Strand;
 use bio::io::gff::{self, Phase};
 use bio::stats::LogProb;
+use genebears::GeneBears;
 use genebears::Genome;
 use itertools::Itertools;
 use log::{info, warn};
@@ -24,6 +25,7 @@ use rust_htslib::bgzf::CompressionLevel::Default;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
 use super::node;
 
@@ -240,7 +242,7 @@ impl Transcript {
         max_haplotypes: usize,
         distance_metric: DistanceMetric,
         genome_build: Genome,
-        genebe_cache: &Option<PathBuf>,
+        genebe_client: &Arc<Mutex<GeneBears>>,
     ) -> Result<
         Vec<(
             EffectScore,
@@ -264,7 +266,7 @@ impl Transcript {
             )?;
             let frequency = haplotype_metric.calculate(&haplotype);
             let annotation =
-                Annotation::from_haplotype(&haplotype, self, genome_build, genebe_cache)?;
+                Annotation::from_haplotype(&haplotype, self, genome_build, genebe_client)?;
             scores.push((effect_score, frequency, supporting_reads, annotation));
         }
         Ok(scores)

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,11 +98,10 @@ impl Command {
                 info!("Reading reference genome from {reference:?}");
                 let reference_genome = utils::fasta::read_reference(reference);
                 let write_lock = Arc::new(Mutex::new(()));
-                let config = if let Some(cache) = genebe_cache {
-                    ClientConfig::default().with_cache(cache)
-                } else {
-                    ClientConfig::default()
-                };
+                let mut config = ClientConfig::default();
+                if let Some(cache) = genebe_cache {
+                    config = config.with_cache(cache);
+                }
                 let client = Arc::new(Mutex::new(GeneBears::new(config)?));
                 let transcripts = transcripts(features, graph)?;
                 let total = transcripts.len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use bio::io::gff::GffType;
 use bio::stats::{LogProb, Prob};
 use clap::Parser;
 use env_logger::Env;
+use genebears::{ClientConfig, GeneBearError, GeneBears};
 use itertools::Itertools;
 use log::{debug, info};
 use rayon::prelude::*;
@@ -97,6 +98,12 @@ impl Command {
                 info!("Reading reference genome from {reference:?}");
                 let reference_genome = utils::fasta::read_reference(reference);
                 let write_lock = Arc::new(Mutex::new(()));
+                let config = if let Some(cache) = genebe_cache {
+                    ClientConfig::default().with_cache(cache)
+                } else {
+                    ClientConfig::default()
+                };
+                let client = Arc::new(Mutex::new(GeneBears::new(config)?));
                 let transcripts = transcripts(features, graph)?;
                 let total = transcripts.len();
                 transcripts.into_par_iter().enumerate().try_for_each(
@@ -114,7 +121,7 @@ impl Command {
                             *max_haplotypes_per_transcript,
                             *distance_metric,
                             *genome_build,
-                            genebe_cache,
+                            &client,
                         )?;
                         info!(
                             "Writing scores for {} different haplotypes for transcript {}",


### PR DESCRIPTION
This pull request refactors how the `GeneBears` client is managed and passed throughout the codebase, moving from passing around an optional path to a cache file to using a shared, thread-safe `Arc<Mutex<GeneBears>>` instance. This change ensures that the client is reused across threads and components, improving efficiency and thread safety when annotating variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal resource initialization and client management architecture in the annotation and transcript scoring pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fxwiegand/predictosaurus/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->