### PR TITLE
fix: Deduplicate haplotypes after intron removal

### DIFF
--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -15,7 +15,7 @@ use std::fmt::Display;
 use std::str::FromStr;
 use varlociraptor::variants::evidence::observations::read_observation::ProcessedReadObservation;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[allow(dead_code)] // TODO: Remove this attribute when graph is properly serialized
 pub(crate) enum NodeType {
     Variant,

--- a/src/graph/transcript.rs
+++ b/src/graph/transcript.rs
@@ -234,7 +234,14 @@ impl Transcript {
             .unique_by(|(nodes, _)| {
                 nodes
                     .iter()
-                    .map(|n| (n.pos, n.alternative_allele.clone()))
+                    .map(|n| {
+                        (
+                            n.pos,
+                            n.node_type.clone(),
+                            n.reference_allele.clone(),
+                            n.alternative_allele.clone(),
+                        )
+                    })
                     .collect_vec()
             })
             .collect())

--- a/src/graph/transcript.rs
+++ b/src/graph/transcript.rs
@@ -231,6 +231,12 @@ impl Transcript {
 
                 (filtered_nodes, filtered_edges)
             })
+            .unique_by(|(nodes, _)| {
+                nodes
+                    .iter()
+                    .map(|n| (n.pos, n.alternative_allele.clone()))
+                    .collect_vec()
+            })
             .collect())
     }
 


### PR DESCRIPTION
This pull request introduces a deduplication step to the transcript graph filtering process by ensuring that only unique sets of nodes (based on position and alternative allele as `Node` itself doesnt implement `Eq + Hash`) are kept.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated haplotype deduplication logic to use genomic position and alternative allele information for more accurate variant comparison.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fxwiegand/predictosaurus/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->