### PR TITLE
fix: Skip nodes with star alternative allele

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -137,6 +137,9 @@ impl VariantGraph {
             let alleles = calls_record.alleles();
             let ref_allele = String::from_utf8(alleles[0].to_vec())?;
             let alt_allele = String::from_utf8(alleles[1].to_vec())?;
+            if alt_allele == "*" {
+                continue;
+            }
 
             let event_probs = EventProbs::from_record(&calls_record, &tags);
             if !event_probs.is_valid() {


### PR DESCRIPTION
This pull request introduces a small but important update to the `VariantGraph` implementation. The change ensures that variant records with an alternate allele of `"*"` are skipped during processing, which helps avoid handling symbolic alleles that are not actual variants.

* Skips processing of variant records in `VariantGraph` where the alternate allele is `"*"`, preventing symbolic alleles from being included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variant record processing to correctly handle and skip records with wildcard alternate alleles, ensuring downstream analysis is not affected by invalid data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->