### PR TITLE
feat: Allow writing full hgvsg notation including reference nodes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -135,7 +135,7 @@ pub(crate) enum Command {
         #[clap(short, long)]
         input: PathBuf,
 
-        /// Format of the haplotype notation to use in the output. Must be one of `hgvsg`, `hgvsc`, or `hgvsgfull`.
+        /// Format of the haplotype notation to use in the output. Must be one of `hgvsg`, `hgvsc`, or `hgvsg-full`.
         #[clap(short, long, default_value = "hgvsg")]
         notation: HgvsNotation,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -135,7 +135,7 @@ pub(crate) enum Command {
         #[clap(short, long)]
         input: PathBuf,
 
-        /// Format of the haplotype notation to use in the output. Must be one of `hgvsg` or `hgvsc`.
+        /// Format of the haplotype notation to use in the output. Must be one of `hgvsg`, `hgvsc`, or `hgvsgfull`.
         #[clap(short, long, default_value = "hgvsg")]
         notation: HgvsNotation,
 
@@ -205,6 +205,7 @@ pub enum HgvsNotation {
     #[default]
     Hgvsg,
     Hgvsc,
+    HgvsgFull,
 }
 
 #[derive(Debug, Clone)]

--- a/src/graph/duck.rs
+++ b/src/graph/duck.rs
@@ -178,7 +178,7 @@ pub(crate) fn variants_on_graph(path: &PathBuf) -> Result<HashMap<String, BTreeS
 pub(crate) fn create_scores(output_path: &Path) -> Result<()> {
     let db = Connection::open(output_path)?;
     db.execute(
-        "CREATE TABLE scores (transcript String, score FLOAT, frequencies String, hgvsc String, hgvsg String, supporting_reads String, annotation String)",
+        "CREATE TABLE scores (transcript String, score FLOAT, frequencies String, hgvsc String, hgvsg String, hgvsg_full String, supporting_reads String, annotation String)",
         [],
     )?;
     db.close().unwrap();
@@ -197,7 +197,7 @@ pub(crate) fn write_scores(
 ) -> Result<()> {
     let mut db = Connection::open(path)?;
     let transaction = db.transaction()?;
-    let mut stmt = transaction.prepare("INSERT INTO scores VALUES (?, ?, ?, ?, ?, ?, ?)")?;
+    let mut stmt = transaction.prepare("INSERT INTO scores VALUES (?, ?, ?, ?, ?, ?, ?, ?)")?;
     let transcript_name = transcript.name();
     for (score, frequencies, supporting_reads, annotation) in scores {
         stmt.execute(params![
@@ -206,6 +206,7 @@ pub(crate) fn write_scores(
             json5::to_string(&frequencies)?,
             score.hgvsc,
             score.hgvsg,
+            score.hgvsg_full,
             json5::to_string(&supporting_reads)?,
             json5::to_string(&annotation)?,
         ])?;
@@ -233,7 +234,7 @@ pub(crate) fn read_scores(
     let db = Connection::open(path)?;
     let mut scores = HashMap::new();
     let mut stmt = db.prepare(
-        "SELECT transcript, score, frequencies, hgvsc, hgvsg, supporting_reads, annotation FROM scores",
+        "SELECT transcript, score, frequencies, hgvsc, hgvsg, hgvsg_full, supporting_reads, annotation FROM scores",
     )?;
     let mut rows = stmt.query([])?;
     while let Some(row) = rows.next()? {
@@ -242,11 +243,13 @@ pub(crate) fn read_scores(
         let frequencies: String = row.get(2)?;
         let hgvsc: String = row.get(3)?;
         let hgvsg: String = row.get(4)?;
-        let supporting_reads: String = row.get(5)?;
-        let annotation: String = row.get(6)?;
+        let hgvsg_full: String = row.get(5)?;
+        let supporting_reads: String = row.get(6)?;
+        let annotation: String = row.get(7)?;
         let haplotype = match notation {
             HgvsNotation::Hgvsc => hgvsc,
             HgvsNotation::Hgvsg => hgvsg,
+            HgvsNotation::HgvsgFull => hgvsg_full,
         };
         scores.entry(transcript).or_insert(Vec::new()).push((
             score,
@@ -659,6 +662,7 @@ mod tests {
             realign: false,
             hgvsc: "c.[100A>G;105C>T]".to_string(),
             hgvsg: "g.[100A>G;105C>T]".to_string(),
+            hgvsg_full: "g.[100A>G;105C>T]".to_string(),
         };
         let frequencies = HashMap::from([("A".to_string(), 0.1), ("C".to_string(), 0.2)]);
         let supporting_reads = vec![HashMap::from([("A".to_string(), 10), ("C".to_string(), 5)])];

--- a/src/graph/score.rs
+++ b/src/graph/score.rs
@@ -19,6 +19,7 @@ pub struct EffectScore {
     pub realign: bool,
     pub hgvsc: String,
     pub hgvsg: String,
+    pub hgvsg_full: String,
 }
 
 impl EffectScore {
@@ -48,6 +49,24 @@ impl EffectScore {
                 .collect::<Vec<_>>()
                 .join(";")
         );
+        let hgvsg_full = format!(
+            "g.[{}]",
+            haplotype
+                .iter()
+                .map(|n| {
+                    if n.node_type.is_variant() {
+                        format!("{}{}>{}",
+                            n.pos + 1,
+                            n.reference_allele,
+                            n.alternative_allele
+                        )
+                    } else {
+                        format!("{}=", n.pos + 1)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(";")
+        );
         if transcript.strand == Strand::Reverse {
             variants.reverse();
         }
@@ -66,6 +85,7 @@ impl EffectScore {
             realign,
             hgvsc,
             hgvsg,
+            hgvsg_full,
         })
     }
 
@@ -340,6 +360,7 @@ mod tests {
             realign: false,
             hgvsc: "c.[100A>G;105C>T]".to_string(),
             hgvsg: "g.[100A>G;105C>T]".to_string(),
+            hgvsg_full: "g.[100A>G;105C>T]".to_string(),
         };
         assert!(score.score().abs() < 1e-6);
     }
@@ -355,6 +376,7 @@ mod tests {
             realign: false,
             hgvsc: "c.[100A>G;105C>T]".to_string(),
             hgvsg: "g.[100A>G;105C>T]".to_string(),
+            hgvsg_full: "g.[100A>G;105C>T]".to_string(),
         };
         // Distance between Leucine and Valine is 0.03 / 2 since len = 2
         assert!((score.score() - 0.015).abs() < 1e-6)
@@ -379,6 +401,7 @@ mod tests {
             realign: false,
             hgvsc: "c.[100A>G;105C>T]".to_string(),
             hgvsg: "g.[100A>G;105C>T]".to_string(),
+            hgvsg_full: "g.[100A>G;105C>T]".to_string(),
         };
         assert!((score.score() - (2.0 / 3.0)).abs() < 1e-6)
     }
@@ -398,6 +421,7 @@ mod tests {
             realign: true,
             hgvsc: "c.[100A>G;105C>T]".to_string(),
             hgvsg: "g.[100A>G;105C>T]".to_string(),
+            hgvsg_full: "g.[100A>G;105C>T]".to_string(),
         };
         assert!((score.score() - 0.5).abs() < 1e-6)
     }
@@ -426,6 +450,7 @@ mod tests {
             realign: true,
             hgvsc: "c.[100A>G;105C>T]".to_string(),
             hgvsg: "g.[100A>G;105C>T]".to_string(),
+            hgvsg_full: "g.[100A>G;105C>T]".to_string(),
         };
         assert!((score.score() - 0.2).abs() < 1e-6)
     }

--- a/src/graph/score.rs
+++ b/src/graph/score.rs
@@ -55,7 +55,8 @@ impl EffectScore {
                 .iter()
                 .map(|n| {
                     if n.node_type.is_variant() {
-                        format!("{}{}>{}",
+                        format!(
+                            "{}{}>{}",
                             n.pos + 1,
                             n.reference_allele,
                             n.alternative_allele


### PR DESCRIPTION
Allow outputting reference nodes as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a new comprehensive haplotype notation format option that displays detailed genomic position information for all sequenced positions, including both variant changes and reference positions. Users can now select this enhanced format to view more complete sequence representation, supporting comprehensive variant documentation and thorough genomic analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->