### PR TITLE
fix: Classify read support with reciprocal Bayes factor

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -187,24 +187,25 @@ impl VariantGraph {
 
             for (sample, observations) in observations {
                 for observation in observations {
-                    let evidence = BayesFactor::new(observation.prob_alt(), observation.prob_ref())
-                        .evidence_kass_raftery();
-                    match evidence {
-                        KassRaftery::Strong | KassRaftery::VeryStrong => {
-                            // Read supports variant
-                            let entry = supporting_reads
+                    let supports_allele = |numerator, denominator| {
+                        matches!(
+                            BayesFactor::new(numerator, denominator).evidence_kass_raftery(),
+                            KassRaftery::Positive | KassRaftery::Strong | KassRaftery::VeryStrong
+                        )
+                    };
+                    if supports_allele(observation.prob_alt(), observation.prob_ref()) {
+                        // Read supports variant
+                        supporting_reads
+                            .entry((sample.to_string(), observation.fragment_id))
+                            .or_insert(Vec::new())
+                            .push(var_node_index);
+                    } else if supports_allele(observation.prob_ref(), observation.prob_alt()) {
+                        // Read supports reference
+                        if let Some(index) = ref_node_index {
+                            supporting_reads
                                 .entry((sample.to_string(), observation.fragment_id))
-                                .or_insert(Vec::new());
-                            entry.push(var_node_index);
-                        }
-                        KassRaftery::None | KassRaftery::Barely | KassRaftery::Positive => {
-                            // Read supports reference
-                            let entry = supporting_reads
-                                .entry((sample.to_string(), observation.fragment_id))
-                                .or_insert(Vec::new());
-                            if let Some(index) = ref_node_index {
-                                entry.push(index);
-                            }
+                                .or_insert(Vec::new())
+                                .push(index);
                         }
                     }
                 }


### PR DESCRIPTION
This pull request refactors how evidence strength is evaluated when determining whether a read supports a variant or the reference. The main change is the introduction of a helper closure to clarify and unify the logic for evaluating support, as well as an update to the threshold for what counts as supporting evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated allele classification logic to more accurately identify reads supporting variants based on confidence assessment levels, improving the precision of variant calling results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->