### PR TITLE
feat: Add --report-protein flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -139,6 +139,10 @@ pub(crate) enum Command {
         #[clap(short, long, default_value = "hgvsg")]
         notation: HgvsNotation,
 
+        /// Output the alternative protein sequence as an additional column.
+        #[clap(long)]
+        report_protein: bool,
+
         /// Path to the output TSV file containing the predicted scores per transcript.
         #[clap(short, long)]
         output: PathBuf,

--- a/src/graph/duck.rs
+++ b/src/graph/duck.rs
@@ -178,7 +178,7 @@ pub(crate) fn variants_on_graph(path: &PathBuf) -> Result<HashMap<String, BTreeS
 pub(crate) fn create_scores(output_path: &Path) -> Result<()> {
     let db = Connection::open(output_path)?;
     db.execute(
-        "CREATE TABLE scores (transcript String, score FLOAT, frequencies String, hgvsc String, hgvsg String, hgvsg_full String, supporting_reads String, annotation String)",
+        "CREATE TABLE scores (transcript String, score FLOAT, frequencies String, hgvsc String, hgvsg String, hgvsg_full String, supporting_reads String, annotation String, protein String)",
         [],
     )?;
     db.close().unwrap();
@@ -197,7 +197,7 @@ pub(crate) fn write_scores(
 ) -> Result<()> {
     let mut db = Connection::open(path)?;
     let transaction = db.transaction()?;
-    let mut stmt = transaction.prepare("INSERT INTO scores VALUES (?, ?, ?, ?, ?, ?, ?, ?)")?;
+    let mut stmt = transaction.prepare("INSERT INTO scores VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")?;
     let transcript_name = transcript.name();
     for (score, frequencies, supporting_reads, annotation) in scores {
         stmt.execute(params![
@@ -209,6 +209,7 @@ pub(crate) fn write_scores(
             score.hgvsg_full,
             json5::to_string(&supporting_reads)?,
             json5::to_string(&annotation)?,
+            score.altered_protein.to_string(),
         ])?;
     }
     transaction.commit()?;
@@ -228,13 +229,14 @@ pub(crate) fn read_scores(
             String,
             Vec<HashMap<String, u32>>,
             Annotation,
+            String,
         )>,
     >,
 > {
     let db = Connection::open(path)?;
     let mut scores = HashMap::new();
     let mut stmt = db.prepare(
-        "SELECT transcript, score, frequencies, hgvsc, hgvsg, hgvsg_full, supporting_reads, annotation FROM scores",
+        "SELECT transcript, score, frequencies, hgvsc, hgvsg, hgvsg_full, supporting_reads, annotation, protein FROM scores",
     )?;
     let mut rows = stmt.query([])?;
     while let Some(row) = rows.next()? {
@@ -246,6 +248,7 @@ pub(crate) fn read_scores(
         let hgvsg_full: String = row.get(5)?;
         let supporting_reads: String = row.get(6)?;
         let annotation: String = row.get(7)?;
+        let protein: String = row.get(8)?;
         let haplotype = match notation {
             HgvsNotation::Hgvsc => hgvsc,
             HgvsNotation::Hgvsg => hgvsg,
@@ -257,6 +260,7 @@ pub(crate) fn read_scores(
             haplotype,
             json5::from_str(&supporting_reads)?,
             json5::from_str(&annotation)?,
+            protein,
         ));
     }
     db.close().unwrap();
@@ -702,5 +706,6 @@ mod tests {
                 ("C".to_string(), 5u32)
             ])]
         );
+        assert_eq!(scores.get("chr1:some feature").unwrap()[0].5, "IL");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,13 +169,14 @@ impl Command {
             Command::Plot {
                 input,
                 notation,
+                report_protein,
                 output,
             } => {
                 if let Some(parent) = output.parent() {
                     create_output_dir(parent)?;
                 }
                 let scores = read_scores(input, *notation)?;
-                render_scores(output, &scores)?;
+                render_scores(output, &scores, *report_protein)?;
             }
         }
         Ok(())

--- a/src/show/mod.rs
+++ b/src/show/mod.rs
@@ -85,6 +85,7 @@ pub(crate) fn render_html_paths(
 ///
 /// * `output_path` - A reference to a `PathBuf` that holds the path of the output TSV file.
 /// * `scores` - A reference to a `HashMap` that holds the scores, likelihoods, and haplotypes for each transcript.
+/// * `report_protein` - Whether to include the alternative protein sequence as an additional column.
 pub(crate) fn render_scores(
     output_path: &PathBuf,
     scores: &HashMap<
@@ -95,8 +96,10 @@ pub(crate) fn render_scores(
             String,
             Vec<HashMap<String, u32>>,
             Annotation,
+            String,
         )>,
     >,
+    report_protein: bool,
 ) -> Result<()> {
     let mut wtr = WriterBuilder::new()
         .delimiter(b'\t')
@@ -107,7 +110,7 @@ pub(crate) fn render_scores(
         .flat_map(|scores| {
             scores
                 .iter()
-                .flat_map(|(_, sample_scores, _, _, _)| sample_scores.keys().cloned())
+                .flat_map(|(_, sample_scores, _, _, _, _)| sample_scores.keys().cloned())
         })
         .unique()
         .collect();
@@ -121,12 +124,17 @@ pub(crate) fn render_scores(
         "spliceai_score".to_string(),
         "alphamissense_score".to_string(),
     ];
+    if report_protein {
+        headers.push("protein".to_string());
+    }
     headers.extend(samples.iter().map(|s| format!("{}:frequency", s)));
     headers.extend(samples.iter().map(|s| format!("{}:supporting_reads", s)));
     wtr.write_record(headers)?;
 
     for (transcript, hap_scores) in scores {
-        for (score_val, sample_scores, haplotype, supporting_reads, annotation) in hap_scores {
+        for (score_val, sample_scores, haplotype, supporting_reads, annotation, protein) in
+            hap_scores
+        {
             let mut row = vec![
                 transcript.to_string(),
                 score_val.to_string(),
@@ -144,6 +152,9 @@ pub(crate) fn render_scores(
                     .alphamissense_score
                     .map_or("".to_string(), |s| s.to_string()),
             ];
+            if report_protein {
+                row.push(protein.to_string());
+            }
             for sample in &samples {
                 let val = sample_scores.get(sample).ok_or_else(|| {
                     anyhow!(
@@ -259,13 +270,16 @@ mod tests {
                     ("C".to_string(), 5u32),
                 ])],
                 annotion,
+                "FL".to_string(),
             )],
         )]);
-        render_scores(&output_path, &scores).unwrap();
+        render_scores(&output_path, &scores, true).unwrap();
         let content = std::fs::read_to_string(&output_path).unwrap();
         assert!(output_path.exists());
         assert!(content.contains("transcript"));
         assert!(content.contains("chr1:some feature"));
         assert!(content.contains("10"));
+        assert!(content.contains("protein"));
+        assert!(content.contains("FL"));
     }
 }


### PR DESCRIPTION
This PR add a new flag that optionally lets predictosaurus output the altered protein for the given transcript considering all variants on the haplotype.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional protein column to Plot outputs, showing the alternative protein sequence when enabled.
  * Plot results can now include this extra information in generated TSV files.

* **Bug Fixes**
  * Updated result storage and export handling to preserve the protein value consistently from input to output.
  * Adjusted output formatting so column headers and row values stay aligned when the protein field is included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->