### PR TITLE
feat: Handle start lost consequence in scoring

### DIFF
--- a/src/graph/score.rs
+++ b/src/graph/score.rs
@@ -29,9 +29,13 @@ impl EffectScore {
         haplotype: &[Node],
         original_protein: Protein,
         distance_metric: DistanceMetric,
-        realign: bool,
+        mut realign: bool,
     ) -> Result<Self> {
-        let altered_protein = Protein::from_haplotype(reference, transcript, haplotype)?;
+        let mut altered_protein = Protein::from_haplotype(reference, transcript, haplotype)?;
+        if altered_protein.start_lost(&original_protein) {
+            altered_protein.apply_start_lost();
+            realign = true;
+        }
         let mut variants: Vec<_> = haplotype
             .iter()
             .filter(|n| n.node_type.is_variant())
@@ -93,10 +97,13 @@ impl EffectScore {
     pub fn score(&self) -> f64 {
         // Compare proteins:
         // If equal return 0
+        // If nothing is translated (e.g. a lost start codon without a downstream start) return the maximum penalty
         // If no frameshift occured in the changed protein, simply compare amino acid by amino acid based on the distance metric and divide by the length of the protein
         // If a frameshift occurs, re-align the proteins and compare amino acid by amino acid based on the distance metric and divide by the length of the protein
         if self.original_protein == self.altered_protein {
             0.0
+        } else if self.altered_protein.amino_acids().is_empty() {
+            1.0
         } else if !self.realign {
             // We can assume both proteins have the same length
             let mut total = 0.0;

--- a/src/translation/amino_acids.rs
+++ b/src/translation/amino_acids.rs
@@ -93,6 +93,26 @@ impl Protein {
         Ok(Protein::new(dna_to_amino_acids(&cds_seq)?))
     }
 
+    /// Returns true if the protein has lost the start codon compared to the original protein sequence
+    pub(crate) fn start_lost(&self, original: &Protein) -> bool {
+        matches!(original.sequence.first(), Some(AminoAcid::Methionine))
+            && !matches!(self.sequence.first(), Some(AminoAcid::Methionine))
+    }
+
+    /// Applies the start lost effect to the protein sequence by removing all amino acids before the next methionine if present, otherwise retrunss an empty sequence
+    pub(crate) fn apply_start_lost(&mut self) {
+        let reinitiated = match self
+            .sequence
+            .iter()
+            .skip(1)
+            .position(|amino_acid| *amino_acid == AminoAcid::Methionine)
+        {
+            Some(offset) => self.sequence[offset + 1..].to_vec(),
+            None => Vec::new(),
+        };
+        self.sequence = reinitiated;
+    }
+
     pub fn as_bytes(&self) -> Vec<u8> {
         self.amino_acids()
             .iter()
@@ -578,6 +598,53 @@ mod tests {
                 sequence: vec![AminoAcid::Alanine, AminoAcid::Valine],
             }
         );
+    }
+
+    #[test]
+    fn start_lost_compares_first_residue_against_original() {
+        let original = Protein::new(vec![
+            AminoAcid::Methionine,
+            AminoAcid::Leucine,
+            AminoAcid::Valine,
+        ]);
+        assert!(Protein::new(vec![
+            AminoAcid::Threonine,
+            AminoAcid::Leucine,
+            AminoAcid::Valine
+        ])
+        .start_lost(&original));
+        assert!(!Protein::new(vec![
+            AminoAcid::Methionine,
+            AminoAcid::Tryptophan,
+            AminoAcid::Valine
+        ])
+        .start_lost(&original));
+        let without_annotated_start = Protein::new(vec![AminoAcid::Leucine, AminoAcid::Valine]);
+        assert!(!Protein::new(vec![AminoAcid::Threonine, AminoAcid::Valine])
+            .start_lost(&without_annotated_start));
+    }
+
+    #[test]
+    fn apply_start_lost_restarts_at_next_methionine() {
+        let mut protein = Protein::new(vec![
+            AminoAcid::Threonine,
+            AminoAcid::Leucine,
+            AminoAcid::Methionine,
+            AminoAcid::Valine,
+        ]);
+        protein.apply_start_lost();
+        assert_eq!(
+            protein.sequence,
+            vec![AminoAcid::Methionine, AminoAcid::Valine]
+        );
+
+        let mut without_downstream_start = Protein::new(vec![
+            AminoAcid::Threonine,
+            AminoAcid::Leucine,
+            AminoAcid::Valine,
+        ]);
+        without_downstream_start.apply_start_lost();
+        assert!(without_downstream_start.sequence.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
This PR extends the scoring by handling start lost properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling proteins that lose their start, including restarting at the next methionine when available.
* **Bug Fixes**
  * Improved scoring for altered proteins with no translated amino acids, preventing incorrect normalization and returning a full mismatch score when appropriate.
  * Made start-loss handling more robust when realignment is needed during scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->