### PR TITLE
feat: Use probabilistic or for score aggregation across haplotypes

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -89,11 +89,10 @@ fn max_score(iter: impl Iterator<Item = Option<f64>>) -> Option<f64> {
 }
 
 fn probabilistic_or(iter: impl Iterator<Item = Option<f64>>) -> Option<f64> {
-    let scores: Vec<f64> = iter.flatten().collect();
-    if scores.is_empty() {
-        return None;
-    }
-    Some(1.0 - scores.iter().map(|score| 1.0 - score).product::<f64>())
+    iter.flatten()
+        .map(|score| 1.0 - score)
+        .reduce(|acc, complement| acc * complement)
+        .map(|product| 1.0 - product)
 }
 
 #[cfg(test)]

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -76,14 +76,50 @@ impl Annotation {
         };
 
         Ok(Self {
-            revel_score: max_score(results.iter().map(|r| r.revel_score)),
+            revel_score: probabilistic_or(results.iter().map(|r| r.revel_score)),
             acmg_score: max_score(results.iter().map(|r| r.acmg_score)),
-            spliceai_score: max_score(results.iter().map(|r| r.spliceai_max_score)),
-            alphamissense_score: max_score(results.iter().map(|r| r.alphamissense_score)),
+            spliceai_score: probabilistic_or(results.iter().map(|r| r.spliceai_max_score)),
+            alphamissense_score: probabilistic_or(results.iter().map(|r| r.alphamissense_score)),
         })
     }
 }
 
 fn max_score(iter: impl Iterator<Item = Option<f64>>) -> Option<f64> {
     iter.flatten().reduce(f64::max)
+}
+
+fn probabilistic_or(iter: impl Iterator<Item = Option<f64>>) -> Option<f64> {
+    let scores: Vec<f64> = iter.flatten().collect();
+    if scores.is_empty() {
+        return None;
+    }
+    Some(1.0 - scores.iter().map(|score| 1.0 - score).product::<f64>())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probabilistic_or_of_a_single_score_is_unchanged() {
+        let result = probabilistic_or([Some(0.6)].into_iter()).unwrap();
+        assert!((result - 0.6).abs() < 1e-9);
+    }
+
+    #[test]
+    fn probabilistic_or_combines_as_complement_of_product() {
+        let result = probabilistic_or([Some(0.5), Some(0.5)].into_iter()).unwrap();
+        assert!((result - 0.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn probabilistic_or_ignores_absent_scores() {
+        let result = probabilistic_or([Some(0.5), None, Some(0.5)].into_iter()).unwrap();
+        assert!((result - 0.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn probabilistic_or_without_scores_is_none() {
+        assert_eq!(probabilistic_or([None, None].into_iter()), None);
+    }
 }


### PR DESCRIPTION
This PR makes predictosaurus use a probabilistic or approach to aggregate spliceai, revel and alphamissense scores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved aggregation of multiple variant prediction scores for more representative combined results.
  * Missing prediction values are now handled correctly without affecting available scores.
  * ACMG score aggregation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->